### PR TITLE
Extract Snippets module from JoinerImpl

### DIFF
--- a/_includes/snippet.html
+++ b/_includes/snippet.html
@@ -1,5 +1,6 @@
-{% if s.version == 'v1' %}
-<pre class='snippets-v1'>{{ s.snippets }}</pre>
+{% unless s.markdown == true %}
+<pre class='snippets-no-md'>{{ s.last-week }}{% if s.this-week %}<br/>
+{{ s.this-week }}{% endif %}</pre>
 {% else %}
 <div class='snippets'>
 <h3>Last Week</h3>
@@ -9,4 +10,4 @@
 <div>{{ s.this-week | markdownify }}</div>
 {% endif %}
 </div>
-{% endif %}
+{% endunless %}

--- a/_plugins/hub.rb
+++ b/_plugins/hub.rb
@@ -13,6 +13,7 @@ module Hub
     # for the Hub.
     def generate(site)
       Joiner.join_data(site)
+      Snippets.publish(site)
       CrossReferencer.build_xrefs(site.data)
       Canonicalizer.canonicalize_data(site.data)
       PrivateAssets.copy_to_site(site)

--- a/_plugins/joiner.rb
+++ b/_plugins/joiner.rb
@@ -204,7 +204,6 @@ module Hub
       ['last-week', 'this-week'].each do |field|
         text = snippet[field] || ''
         redact! text
-        text.gsub!(/^\n\n+/m, '')
 
         parsed = []
         uses_item_markers = (text =~ /^[-*]/)
@@ -243,10 +242,9 @@ module Hub
     # remove the markers.
     def redact!(text)
       if @public_mode
-        text.gsub!(/\{\{.*?\}\}/m,'')
+        text.gsub!(/\n?\{\{.*?\}\}/m,'')
       else
-        text.gsub!(/\{\{/,'')
-        text.gsub!(/\}\}/,'')
+        text.gsub!(/(\{\{|\}\})/,'')
       end
     end
 

--- a/_plugins/snippets.rb
+++ b/_plugins/snippets.rb
@@ -1,5 +1,23 @@
+require_relative 'snippets_publisher'
+
 module Hub
   class Snippets
+    # Used to convert snippet headline markers to h4, since the layout uses
+    # h3.
+    HEADLINE = "\n####"
+
+    MARKDOWN_SNIPPET_MUNGER = Proc.new do |text|
+      text.gsub!(/^::: (.*) :::$/, "#{HEADLINE} \\1") # For jtag. ;-)
+      text.gsub!(/^\*\*\*/, HEADLINE) # For elaine. ;-)
+    end
+
+    def self.publish(site)
+      publisher = ::Snippets::Publisher.new(
+        headline: HEADLINE, public_mode: site.config['public'],
+        markdown_snippet_munger: MARKDOWN_SNIPPET_MUNGER)
+      site.data['snippets'] = publisher.publish site.data['snippets']
+    end
+
     def self.generate_pages(site)
       return unless site.data.member? 'snippets'
       site.data['snippets'].each do |timestamp, snippets|

--- a/_plugins/snippets_publisher.rb
+++ b/_plugins/snippets_publisher.rb
@@ -1,0 +1,94 @@
+module Snippets
+  class Publisher
+    # @param headline [String] Markdown string used to markup each section
+    #   title within a block of snippet text
+    # @param public_mode [true, false, or nil] indicates whether or not the
+    #   snippets are to be published publicly; private snippets and redacted
+    #   spans of text will not be published when +public_mode+ is true
+    # @param markdown_snippet_munger [Proc] the code block that will be called
+    #   with a String of snippet text after redaction and before Markdown
+    #   preparation, to modify the snippet text String in-place; will not be
+    #   called if the snippet's version doesn't support Markdown syntax
+    def initialize(headline:, public_mode:, markdown_snippet_munger:nil)
+      @headline = headline
+      @public_mode = public_mode
+      @markdown_snippet_munger = markdown_snippet_munger
+    end
+
+    # Processes +snippets+ entries for publication. Any snippets that should
+    # not appear when in +public_mode+ are removed from +snippets+
+    def publish(snippets)
+      result = {}
+      snippets.each do |timestamp, snippet_batch|
+        published = []
+        snippet_batch.each do |snippet|
+          unless @public_mode and !snippet['public']
+            publish_snippet(snippet, published)
+          end
+        end
+        result[timestamp] = published unless published.empty?
+      end
+      result
+    end
+
+    # Parses and publishes a snippet. Filters out snippets rendered empty
+    # after redaction.
+    # @param snippet [Hash<String,String>] snippet hash with two fields:
+    #   +last-week+ and +this-week+
+    # @param published [Array<Hash<String,String>>] array of published snippets
+    def publish_snippet(snippet, published)
+      ['last-week', 'this-week'].each do |field|
+        text = snippet[field] || ''
+        redact! text
+        if snippet['markdown']
+          @markdown_snippet_munger.yield text if @markdown_snippet_munger
+          text = prepare_markdown text
+        end
+        snippet[field] = text.empty? ? nil : text
+      end
+
+      is_empty = (snippet['last-week'] || '').empty? && (
+        snippet['this-week'] || '').empty?
+      published << snippet unless is_empty
+    end
+
+    # Parses "{{" and "}}" redaction markers. For public snippets, will redact
+    # everything between each set of markers. For internal snippets, will only
+    # remove the markers.
+    def redact!(text)
+      if @public_mode
+        text.gsub!(/\n?\{\{.*?\}\}/m,'')
+      else
+        text.gsub!(/(\{\{|\}\})/,'')
+      end
+    end
+
+    # Processes snippet text in Markdown format to smooth out any anomalies
+    # before rendering. Also translates arbitrary plaintext to Markdown.
+    #
+    # @param text [String] snippet text
+    # @return [String]
+    def prepare_markdown(text)
+      parsed = []
+      uses_item_markers = (text =~ /^[-*]/)
+
+      text.each_line do |line|
+        line.rstrip!
+        # Convert headline markers.
+        line.sub!(/^(#+)/, @headline)
+
+        # Add item markers for those who used plaintext and didn't add them;
+        # add headline markers for those who defined different sections and
+        # didn't add them.
+        if line =~ /^([A-Za-z0-9])/
+          line = uses_item_markers ? "#{@headline} #{line}" : "- #{line}"
+        end
+
+        # Fixup item markers missing a space.
+        line.sub!(/^[-*]([^ ])/, '- \1')
+        parsed << line unless line.empty?
+      end
+      parsed.join("\n")
+    end
+  end
+end

--- a/_plugins/snippets_version.rb
+++ b/_plugins/snippets_version.rb
@@ -1,0 +1,91 @@
+module Snippets
+  # Encapsulates the mapping from actual snippet data fields to a standardized
+  # set of internal data fields for each version of snippets.
+  #
+  # Snippets are expected to be imported from CSV files. Since we've tried a
+  # handful of different formats, with slightly different field names and
+  # semantics, we need a way to transform them into a common format before
+  # generating pages, to streamline the logic and possibly allow for even more
+  # formats in the future without requiring version-specific hacks.
+  class Version
+    # Set of field name values that the +field_map+ argument of +initialize+
+    # must map to.
+    FIELD_NAMES = ['username', 'last-week', 'this-week', 'timestamp']
+
+    # Raised by +initialize+ when the initialization parameters are flawed.
+    class InitError < ::Exception
+    end
+
+    attr_reader(:version_name, :field_map, :public_field, :public_value,
+      :markdown_supported)
+
+    # @param version_name [String] identifies the version, e.g. "v3"
+    # @param field_map [Hash<String, String>] contains the mapping from the
+    #   field name in the original data file to the standardized internal
+    #   field name
+    # @param public_field [String] if present, the field that indicates whether
+    #   or not a snippet can be published in public mode; if not present, no
+    #   snippets matching this version should be published publicly
+    # @param public_value [String] if present, the value for +public_field+
+    #   that indicates whether or not a snippet should be published in public
+    #   mode
+    # @param markdown_supported [true,false] indicates whether or not the
+    #   snippet version supports Markdown syntax
+    # @raise [InitError] if +field_map+ does not contain mappings for every
+    #   element of FIELD_NAMES
+    # @raise [InitError] if one of +public_field+ or +public_value+ is set, but
+    #   not the other
+    def initialize(version_name:, field_map:, public_field:nil,
+      public_value:nil, markdown_supported: false)
+
+      expected = FIELD_NAMES.sort
+      actual = field_map.values.sort
+      intersection = expected & actual
+
+      unless intersection == expected
+        raise InitError.new("Snippet version \"#{version_name}\" " +
+          "missing mappings for fields: #{expected - intersection}")
+      end
+
+      unless (public_field == nil and public_value == nil) or (
+        public_field != nil and public_value != nil)
+        raise InitError.new("Snippet version \"#{version_name}\" has " +
+          "public_field and public_value mismatched: " +
+          "public_field == #{public_field ? "\"#{public_field}\"" : 'nil'}; " +
+          "public_value == #{public_value ? "\"#{public_value}\"" : 'nil'}")
+      end
+
+      @version_name = version_name
+      @field_map = field_map
+      @public_field = public_field
+      @public_value = public_value
+      @markdown_supported = markdown_supported
+    end
+
+    # Raised by +standardize+ when a snippet contains fields not contained in
+    # +field_map+.
+    class UnknownFieldError < ::Exception
+    end
+
+    # Converts the field names within +snippet+ to standardized names using
+    # +field_map+, and sets snippet[public] and snippet[markdown].
+    #
+    # @param snippet [Hash<String, String>] snippet data to evaluate
+    # @return [Hash<String,String>] +snippet+
+    # @raise [UnknownFieldError] if +snippet+ contains fields not contained in
+    #   +field_map+
+    def standardize(snippet)
+      snippet.keys.each do |k|
+        unless @field_map.member? k
+          raise UnknownFieldError.new("Snippet field not recognized by " +
+            "version \"#{@version_name}\": #{k}")
+        end
+        snippet[@field_map[k]] = snippet.delete k
+      end
+      snippet['public'] = (@public_field and
+        snippet[@public_field] == @public_value) ? true : false
+      snippet['markdown'] = @markdown_supported
+      snippet
+    end
+  end
+end

--- a/_plugins/snippets_version.rb
+++ b/_plugins/snippets_version.rb
@@ -1,12 +1,36 @@
 module Snippets
   # Encapsulates the mapping from actual snippet data fields to a standardized
-  # set of internal data fields for each version of snippets.
+  # set of data fields for each version of snippets.
   #
-  # Snippets are expected to be imported from CSV files. Since we've tried a
-  # handful of different formats, with slightly different field names and
-  # semantics, we need a way to transform them into a common format before
-  # generating pages, to streamline the logic and possibly allow for even more
-  # formats in the future without requiring version-specific hacks.
+  # Since 18F experimented with a handful of different snippet formats, with
+  # slightly different field names and semantics, we needed a way to transform
+  # each batch into a common format before generating Hub pages, to streamline
+  # the logic and possibly allow for even more formats in the future without
+  # requiring version-specific hacks.
+  #
+  # The common format fields are:
+  # - username: identifies the snippet author
+  # - last-week: summary of last week's activity
+  # - this-week: summary of this week's anticipated activity
+  # - timestamp: identifies when the snippet was reported; might not
+  #   necessarily match the timestamp of the batch in which it appears
+  # - public: true if the snippet may be published publicly
+  # - markdown: true if the snippet version supports Markdown syntax
+  #
+  # When using Jekyll, snippet data should be stored in the _data directory
+  # with versioned subdirectories containing timestamped Comma Separated Value
+  # (CSV) files, e.g.:
+  # - _data/snippets/v1/20141110.csv
+  # - _data/snippets/v2/20141201.csv
+  # - _data/snippets/v3/20141208.csv
+  #
+  # Jekyll imports this data into a Hash structure (site.data['snippets'])
+  # resembling:
+  # - version => { timestamp => [ snippets ] }
+  #
+  # Version.standardize_versions will convert this structure into a Hash
+  # resembling:
+  # - timestamp => [ snippets ]
   class Version
     # Set of field name values that the +field_map+ argument of +initialize+
     # must map to.
@@ -86,6 +110,45 @@ module Snippets
         snippet[@public_field] == @public_value) ? true : false
       snippet['markdown'] = @markdown_supported
       snippet
+    end
+
+    # Raised by +standardize_versions+ if a snippet version is unknown.
+    class UnknownVersionError < ::Exception
+    end
+
+    # Transforms snippets of different versions into a standard format.
+    #
+    # The keys of +snippets_by_version+ should indicate the version of the
+    # corresponding batch of snippets, and also match the keys of
+    # +snippet_versions+. Each batch of snippets for each version should be a
+    # Hash from a timestamp string (typically YYYYMMDD) to an Array of Hashes
+    # representing individual snippet entries.
+    #
+    # The resulting Hash will map from timestamp string to an Array of
+    # standardized snippet Hashes, eliminating the now unnecessary version
+    # information.
+    #
+    # @param snippets_by_version [Hash<String, Hash<String, Array<Hash>>>]
+    #   contains: version => { timestamp => [ snippets ] }
+    # @param snippet_versions [Hash<String,Snippets::Version>] mapping from
+    #   snippet version name to the corresponding Snippets::Version object
+    # @return [Hash<String, Array<Hash>>] a mapping from a (weekly) timestamp
+    #   to a corresponding set of standardized snippets
+    #
+    # @raise [UnknownVersionError] if any snippets correspond to versions not
+    #   in +snippet_versions+
+    def self.standardize_versions(snippets_by_version, snippet_versions)
+      result = {}
+      snippets_by_version.each do |version, batch|
+        v = snippet_versions[version]
+        unless v
+          raise UnknownVersionError.new("Unknown snippet version: #{version}")
+        end
+        batch.each do |timestamp, snippets|
+          result[timestamp] = snippets.each {|s| v.standardize s}
+        end
+      end
+      result
     end
   end
 end

--- a/_test/joiner_join_snippet_data_test.rb
+++ b/_test/joiner_join_snippet_data_test.rb
@@ -1,4 +1,5 @@
 require_relative "../_plugins/joiner"
+require_relative "../_plugins/snippets_version"
 require_relative "site"
 
 require "minitest/autorun"
@@ -89,7 +90,7 @@ module Hub
       set_team([])
       add_snippet('v1', '20141218', 'mbland', 'Mike Bland',
         'michael.bland@gsa.gov', 'unused', '- Did stuff', '')
-      error = assert_raises JoinerImpl::SnippetVersionError do
+      error = assert_raises ::Snippets::Version::UnknownVersionError do
         @impl.join_snippet_data({})
       end
       assert_equal "Unknown snippet version: v1", error.to_s

--- a/_test/joiner_join_snippet_data_test.rb
+++ b/_test/joiner_join_snippet_data_test.rb
@@ -70,11 +70,7 @@ module Hub
         Joiner::SNIPPET_VERSIONS[version].standardize s
         s['name'] = name
         s['full_name'] = full_name
-        s['last-week'] = nil if last_week.empty?
-        s['this-week'] = nil if this_week.empty?
-        unless @expected.member? timestamp
-          @expected[timestamp] = []
-        end
+        @expected[timestamp] = [] unless @expected.member? timestamp
         @expected[timestamp] << s
       end
     end
@@ -96,7 +92,7 @@ module Hub
       assert_equal "Unknown snippet version: v1", error.to_s
     end
 
-    def test_publish_nothing_if_no_team
+    def test_joined_snippets_are_empty_if_no_team
       set_team([])
       add_snippet('v1', '20141218', 'mbland', 'Mike Bland',
         'michael.bland@gsa.gov', 'unused', '- Did stuff', '',
@@ -110,7 +106,7 @@ module Hub
       assert_nil @site.data['private']['snippets']
     end
 
-    def test_publish_all_snippets_internally
+    def test_join_all_snippets
       set_team([
         {'name' => 'mbland', 'full_name' => 'Mike Bland',
          'email' => 'michael.bland@gsa.gov'},
@@ -126,34 +122,11 @@ module Hub
       assert_nil @site.data['private']['snippets']
     end
 
-    def test_publish_only_public_v3_snippets_in_public_mode
-      @site.config['public'] = true
-      @impl = JoinerImpl.new(@site)
-
-      set_team([
-        {'name' => 'mbland', 'full_name' => 'Mike Bland',
-         'email' => 'michael.bland@gsa.gov'},
-      ])
-      add_snippet('v1', '20141218', 'mbland', 'Mike Bland',
-        'michael.bland@gsa.gov', 'unused', '- Did stuff', '',
-        expected:false)
-      add_snippet('v2', '20141225', 'mbland', 'Mike Bland',
-        'michael.bland@gsa.gov', '', '- Did stuff', '', expected:false)
-      add_snippet('v3', '20141231', 'mbland', 'Mike Bland',
-        'michael.bland@gsa.gov', 'Public', '- Did stuff', '')
-      add_snippet('v3', '20150107', 'mbland', 'Mike Bland',
-        'michael.bland@gsa.gov', '', '- Did stuff', '', expected:false)
-
-      @impl.join_snippet_data Joiner::SNIPPET_VERSIONS
-      assert_equal @expected, @site.data['snippets']
-      assert_nil @site.data['private']['snippets']
-    end
-
     # This tests the case where we're publishing snippets imported into
     # _data/public using _data/import-public.rb. That script will substitute
     # the original snippets' email usernames with the corresponding Hub
     # username.
-    def test_publish_v3_snippets_with_hub_username_instead_of_email_address
+    def test_join_snippets_with_hub_username_instead_of_email_address
       @site.config['public'] = true
       @impl = JoinerImpl.new(@site)
 

--- a/_test/joiner_publish_snippet_test.rb
+++ b/_test/joiner_publish_snippet_test.rb
@@ -118,6 +118,7 @@ module Hub
       expected = [make_snippet(
         ["#{JoinerImpl::HEADLINE} Jesse style", '- Jesse did stuff'], nil
       )]
+      @impl.set_markdown_snippet_munger Joiner::MARKDOWN_SNIPPET_MUNGER
       @impl.publish_snippet snippet, published
       assert_equal expected, published
     end
@@ -128,6 +129,7 @@ module Hub
       expected = [make_snippet(
         ["#{JoinerImpl::HEADLINE} Elaine style", '- Elaine did stuff'], nil
       )]
+      @impl.set_markdown_snippet_munger Joiner::MARKDOWN_SNIPPET_MUNGER
       @impl.publish_snippet snippet, published
       assert_equal expected, published
     end

--- a/_test/joiner_publish_snippet_test.rb
+++ b/_test/joiner_publish_snippet_test.rb
@@ -13,6 +13,7 @@ module Hub
     def make_snippet(last_week, this_week)
       {'last-week' => last_week ? last_week.join("\n") : last_week,
        'this-week' => this_week ? this_week.join("\n") : this_week,
+       'markdown' => true,
       }
     end
 
@@ -27,6 +28,18 @@ module Hub
       published = []
       @impl.publish_snippet make_snippet([], []), published
       assert_empty published
+    end
+
+    def test_publish_as_is_if_markdown_not_supported
+      snippet = make_snippet(
+        ['Last week:', '- Did Hub stuff',
+         'This week:', '- Will do more Hub stuff'],
+        nil,
+      )
+      snippet['markdown'] = false
+      published = []
+      @impl.publish_snippet snippet, published
+      assert_equal [snippet], published
     end
 
     def test_last_week

--- a/_test/joiner_publish_snippet_test.rb
+++ b/_test/joiner_publish_snippet_test.rb
@@ -11,8 +11,8 @@ module Hub
     end
 
     def make_snippet(last_week, this_week)
-      {'last-week' => last_week.join("\n"),
-       'this-week' => this_week.join("\n"),
+      {'last-week' => last_week ? last_week.join("\n") : last_week,
+       'this-week' => this_week ? this_week.join("\n") : this_week,
       }
     end
 
@@ -100,20 +100,20 @@ module Hub
     end
 
     def test_convert_jesse_style
-      snippet = make_snippet ['::: Jesse style :::', 'Jesse did stuff'], []
+      snippet = make_snippet ['::: Jesse style :::', 'Jesse did stuff'], nil
       published = []
       expected = [make_snippet(
-        ["#{JoinerImpl::HEADLINE} Jesse style", '- Jesse did stuff'], []
+        ["#{JoinerImpl::HEADLINE} Jesse style", '- Jesse did stuff'], nil
       )]
       @impl.publish_snippet snippet, published
       assert_equal expected, published
     end
 
     def test_convert_elaine_style
-      snippet = make_snippet ['*** Elaine style', '-Elaine did stuff'], []
+      snippet = make_snippet ['*** Elaine style', '-Elaine did stuff'], nil
       published = []
       expected = [make_snippet(
-        ["#{JoinerImpl::HEADLINE} Elaine style", '- Elaine did stuff'], []
+        ["#{JoinerImpl::HEADLINE} Elaine style", '- Elaine did stuff'], nil
       )]
       @impl.publish_snippet snippet, published
       assert_equal expected, published

--- a/_test/joiner_redaction_test.rb
+++ b/_test/joiner_redaction_test.rb
@@ -41,17 +41,39 @@ module Hub
     end
 
     def test_multiline_redacted_string_private_mode
-      text = "He{{llo,\nWor}}ld!"
+      text = [
+        '- Did stuff{{ including private details}}',
+        '{{- Did secret stuff}}',
+        '- Did more stuff',
+        '{{- Did more secret stuff',
+        '- Yet more secret stuff}}',
+      ].join('\n')
+      expected = [
+        '- Did stuff including private details',
+        '- Did secret stuff',
+        '- Did more stuff',
+        '- Did more secret stuff',
+        '- Yet more secret stuff',
+      ].join('\n')
       JoinerImpl.new(@site).redact! text
-      assert_equal "Hello,\nWorld!", text
+      assert_equal expected, text
     end
 
     def test_multiline_redacted_string_public_mode
-      text = "He{{llo,\nWor}}ld!"
+      text = [
+        '- Did stuff{{ including private details}}',
+        '{{- Did secret stuff}}',
+        '- Did more stuff',
+        '{{- Did more secret stuff',
+        '- Yet more secret stuff}}',
+      ].join("\n")
+      expected = [
+        '- Did stuff',
+        '- Did more stuff',
+      ].join("\n")
       @site.config['public'] = true
       JoinerImpl.new(@site).redact! text
-      assert_equal "Held!", text
+      assert_equal expected, text
     end
   end
-
 end

--- a/_test/snippets_publish_test.rb
+++ b/_test/snippets_publish_test.rb
@@ -1,0 +1,82 @@
+require_relative "../_plugins/snippets"
+require_relative "site"
+
+require "minitest/autorun"
+
+module Hub
+  class PublishSnippetsTest < ::Minitest::Test
+    def setup
+      @site = DummyTestSite.new
+      @site.data['snippets'] = {}
+      @expected = {}
+    end
+
+    def make_snippet(last_week, is_public: false)
+      {
+        'last-week' => last_week ? last_week.join("\n") : last_week,
+        'this-week' => nil,
+        'markdown' => true,
+        'public' => is_public,
+      }
+    end
+
+    def add_snippet(timestamp, snippet, expected: true)
+      snippets = @site.data['snippets']
+      snippets[timestamp] = [] unless snippets.member? timestamp
+      snippets[timestamp] << snippet
+
+      if expected
+        @expected[timestamp] = [] unless @expected.member? timestamp
+        @expected[timestamp] << snippet
+      end
+    end
+
+    def test_empty_snippets
+      Snippets.publish @site
+      assert_equal @expected, @site.data['snippets']
+    end
+
+    def test_publish_all_snippets
+      add_snippet('20141218', make_snippet(['- Did stuff']))
+      add_snippet('20141225', make_snippet(['- Did stuff']))
+      add_snippet('20141231', make_snippet(['- Did stuff']))
+      add_snippet('20150107', make_snippet(['- Did stuff'], is_public: true))
+      Snippets.publish @site
+      assert_equal @expected, @site.data['snippets']
+    end
+
+    def test_publish_only_public_snippets_in_public_mode
+      add_snippet('20141218', make_snippet(['- Did stuff']), expected: false)
+      add_snippet('20141225', make_snippet(['- Did stuff']), expected: false)
+      add_snippet('20141231', make_snippet(['- Did stuff']), expected: false)
+      add_snippet('20150107', make_snippet(['- Did stuff'], is_public: true))
+      @site.config['public'] = true
+      Snippets.publish @site
+      assert_equal @expected, @site.data['snippets']
+    end
+
+    def test_convert_jesse_style
+      @site.data['snippets']['20150104'] = [
+        make_snippet(['::: Jesse style :::', 'Jesse did stuff'])
+      ]
+      @expected['20150104'] = [
+        make_snippet(
+          ["#{Snippets::HEADLINE} Jesse style", '- Jesse did stuff'])
+      ]
+      Snippets.publish @site
+      assert_equal @expected, @site.data['snippets']
+    end
+
+    def test_convert_elaine_style
+      @site.data['snippets']['20150104'] = [
+        make_snippet(['*** Elaine style', '-Elaine did stuff'])
+      ]
+      @expected['20150104'] = [
+        make_snippet(
+          ["#{Snippets::HEADLINE} Elaine style", '- Elaine did stuff'])
+      ]
+      Snippets.publish @site
+      assert_equal @expected, @site.data['snippets']
+    end
+  end
+end

--- a/_test/snippets_publisher_publish_test.rb
+++ b/_test/snippets_publisher_publish_test.rb
@@ -1,0 +1,55 @@
+require_relative "../_plugins/snippets_publisher"
+
+require "minitest/autorun"
+
+module Snippets
+  class PublisherPublishTest < ::Minitest::Test
+    def setup
+      @original = {}
+      @expected = {}
+    end
+
+    def publisher(public_mode: false)
+      Publisher.new(headline: "\n####", public_mode: public_mode)
+    end
+
+    def make_snippet(last_week, is_public: false)
+      {
+        'last-week' => last_week ? last_week.join("\n") : last_week,
+        'this-week' => nil,
+        'markdown' => true,
+        'public' => is_public,
+      }
+    end
+
+    def add_snippet(timestamp, snippet, expected: true)
+      @original[timestamp] = [] unless @original.member? timestamp
+      @original[timestamp] << snippet
+
+      if expected
+        @expected[timestamp] = [] unless @expected.member? timestamp
+        @expected[timestamp] << snippet
+      end
+    end
+
+    def test_empty_snippets
+      assert_equal @expected, publisher.publish(@original)
+    end
+
+    def test_publish_all_snippets
+      add_snippet('20141218', make_snippet(['- Did stuff']))
+      add_snippet('20141225', make_snippet(['- Did stuff']))
+      add_snippet('20141231', make_snippet(['- Did stuff']))
+      add_snippet('20150107', make_snippet(['- Did stuff'], is_public: true))
+      assert_equal @expected, publisher.publish(@original)
+    end
+
+    def test_publish_only_public_snippets_in_public_mode
+      add_snippet('20141218', make_snippet(['- Did stuff']), expected: false)
+      add_snippet('20141225', make_snippet(['- Did stuff']), expected: false)
+      add_snippet('20141231', make_snippet(['- Did stuff']), expected: false)
+      add_snippet('20150107', make_snippet(['- Did stuff'], is_public: true))
+      assert_equal @expected, publisher(public_mode: true).publish(@original)
+    end
+  end
+end

--- a/_test/snippets_publisher_redaction_test.rb
+++ b/_test/snippets_publisher_redaction_test.rb
@@ -1,42 +1,38 @@
-require_relative "../_plugins/joiner"
-require_relative "site"
+require_relative "../_plugins/snippets_publisher"
 
 require "minitest/autorun"
 
-module Hub
-  class RedactionTest < ::Minitest::Test
-    def setup
-      @site = DummyTestSite.new
+module Snippets
+  class PublisherRedactionTest < ::Minitest::Test
+    def publisher(public_mode: false)
+      Publisher.new(headline: '', public_mode: public_mode)
     end
 
     def test_empty_string
       text = ''
-      JoinerImpl.new(@site).redact! text
+      publisher.redact! text
       assert_empty text
-      @site.config['public'] = true
-      JoinerImpl.new(@site).redact! text
+      publisher(public_mode: true).redact! text
       assert_empty text
     end
 
     def test_unredacted_string
       text = 'Hello, World!'
-      JoinerImpl.new(@site).redact! text
+      publisher.redact! text
       assert_equal 'Hello, World!', text
-      @site.config['public'] = true
-      JoinerImpl.new(@site).redact! text
+      publisher(public_mode: true).redact! text
       assert_equal 'Hello, World!', text
     end
 
     def test_redacted_string_private_mode
       text = 'H{{ell}}o, Wor{{l}}d!'
-      JoinerImpl.new(@site).redact! text
+      publisher.redact! text
       assert_equal 'Hello, World!', text
     end
 
     def test_redacted_string_public_mode
       text = 'H{{ell}}o, Wor{{l}}d!'
-      @site.config['public'] = true
-      JoinerImpl.new(@site).redact! text
+      publisher(public_mode: true).redact! text
       assert_equal 'Ho, Word!', text
     end
 
@@ -55,7 +51,7 @@ module Hub
         '- Did more secret stuff',
         '- Yet more secret stuff',
       ].join('\n')
-      JoinerImpl.new(@site).redact! text
+      publisher.redact! text
       assert_equal expected, text
     end
 
@@ -71,8 +67,7 @@ module Hub
         '- Did stuff',
         '- Did more stuff',
       ].join("\n")
-      @site.config['public'] = true
-      JoinerImpl.new(@site).redact! text
+      publisher(public_mode: true).redact! text
       assert_equal expected, text
     end
   end

--- a/_test/snippets_version_test.rb
+++ b/_test/snippets_version_test.rb
@@ -1,0 +1,137 @@
+require_relative "../_plugins/snippets_version"
+
+require "minitest/autorun"
+
+module Snippets
+  class VersionTest < ::Minitest::Test
+    def test_raises_if_required_field_mapping_missing
+      error = assert_raises Version::InitError do
+        Version.new(
+          version_name:'v1',
+          field_map:{'Username' => 'username', 'Timestamp' => 'timestamp'})
+      end
+      assert_equal(
+        'Snippet version "v1" missing mappings for fields: ' +
+          '["last-week", "this-week"]',
+        error.to_s)
+    end
+
+    def test_raises_if_public_field_is_set_but_public_value_is_not
+      error = assert_raises Version::InitError do
+        Version.new(
+          version_name:'v3',
+          field_map:{
+            'Timestamp' => 'timestamp',
+            'Public' => 'public',
+            'Username' => 'username',
+            'Last week' => 'last-week',
+            'This week' => 'this-week',
+          },
+          public_field: 'public'
+      )
+      end
+      assert_equal(
+        'Snippet version "v3" has public_field and public_value mismatched: ' +
+          'public_field == "public"; public_value == nil',
+        error.to_s)
+    end
+
+    def test_raises_if_public_field_is_not_set_but_public_value_is
+      error = assert_raises Snippets::Version::InitError do
+        Version.new(
+          version_name:'v3',
+          field_map:{
+            'Timestamp' => 'timestamp',
+            'Public' => 'public',
+            'Username' => 'username',
+            'Last week' => 'last-week',
+            'This week' => 'this-week',
+          },
+          public_value: 'Public'
+      )
+      end
+      assert_equal(
+        'Snippet version "v3" has public_field and public_value mismatched: ' +
+          'public_field == nil; public_value == "Public"',
+        error.to_s)
+    end
+
+    def test_raise_if_snippet_contains_unrecognized_fields_not_in_field_map
+      version = Version.new(
+        version_name:'v1',
+        field_map:{
+          'Username' => 'username',
+          'Timestamp' => 'timestamp',
+          'Name' => 'full_name',
+          'Snippets' => 'last-week',
+          'No This Week' => 'this-week',
+        }
+      )
+      error = assert_raises Version::UnknownFieldError do
+        version.standardize({'Public' => ''})
+      end
+      assert_equal('Snippet field not recognized by version "v1": Public',
+        error.to_s)
+    end
+
+    def test_standardize_private_snippet_no_markdown
+      version = Version.new(
+        version_name:'v1',
+        field_map:{
+          'Username' => 'username',
+          'Timestamp' => 'timestamp',
+          'Name' => 'full_name',
+          'Snippets' => 'last-week',
+          'No This Week' => 'this-week',
+        }
+      )
+      snippet = {
+        'Username' => 'mbland',
+        'Timestamp' => '2014-12-31',
+        'Name' => 'Mike Bland',
+        'Snippets' => '- Did stuff',
+      }
+      expected = {
+        'username' => 'mbland',
+        'timestamp' => '2014-12-31',
+        'full_name' => 'Mike Bland',
+        'last-week' => '- Did stuff',
+        'public' => false,
+        'markdown' => false
+      }
+      assert_equal expected, version.standardize(snippet)
+    end
+
+    def test_standardize_public_snippet_with_markdown
+      version = Version.new(
+        version_name:'v3',
+        field_map:{
+          'Timestamp' => 'timestamp',
+          'Public' => 'public',
+          'Username' => 'username',
+          'Last week' => 'last-week',
+          'This week' => 'this-week',
+        },
+        public_field: 'public',
+        public_value: 'Public',
+        markdown_supported: true,
+      )
+      snippet = {
+        'Timestamp' => '2014-12-31',
+        'Public' => 'Public',
+        'Username' => 'mbland',
+        'Last week' => '- Did stuff',
+        'This week' => '- Do more stuff',
+      }
+      expected = {
+        'timestamp' => '2014-12-31',
+        'public' => true,
+        'username' => 'mbland',
+        'last-week' => '- Did stuff',
+        'this-week' => '- Do more stuff',
+        'markdown' => true
+      }
+      assert_equal expected, version.standardize(snippet)
+    end
+  end
+end

--- a/assets/_sass/_hub.scss
+++ b/assets/_sass/_hub.scss
@@ -33,7 +33,7 @@
 
 // Snippets
 //********************************************************
-.snippets-v1 {
+.snippets-no-md {
   white-space: pre-wrap;
 }
 


### PR DESCRIPTION
The goal is to extract a new gem to encapsulate the snippet-manipulation code. Eventually, I'd like to extract as many general-purpose gems as possible so that relatively little code remains in `_plugins`. The ideal is to have the remaining code serve as documentation of how to chain together Hub gems to generate one's own custom Hub instance.

@afeld Let me know if you'd like me to split these commits into separate PRs, if having them all-in-one is too much.