### PR TITLE
Add "Edit data", "Hub Ops" to nav bar

### DIFF
--- a/_data/nav_links.yml
+++ b/_data/nav_links.yml
@@ -1,8 +1,19 @@
 - name: Public Sites
   links:
-    - text: 18f.gsa.gov
-      url: https://18f.gsa.gov/
-    - text: Dashboard
-      url: https://18f.gsa.gov/dashboard/
-    - text: GitHub repos
-      url: https://github.com/18F
+  - text: 18f.gsa.gov
+    url: https://18f.gsa.gov/
+  - text: Dashboard
+    url: https://18f.gsa.gov/dashboard/
+  - text: GitHub repos
+    url: https://github.com/18F
+
+- name: Hub Ops
+  links:
+  - text: Repo
+    url: https://github.com/18F/hub/
+  - text: Issues
+    url: https://github.com/18F/hub/issues
+  - text: Doc WG issues
+    url: https://trello.com/b/cI4LmXOj/wg-documentation
+  - text: Deployment
+    url: https://github.com/18F/hub/blob/master/deploy/README.md

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,11 +3,5 @@
     <div>
       <img src="{{ site.baseurl }}/assets/images/logo-gsa.png" alt="GSA logo"/>
     </div>
-    <div>
-      <h1>Hack the Hub</h1>
-      <a href="https://github.com/18F/hub/">18F Hub repo</a><br/>
-      <a href="https://github.com/18F/hub/tree/master/deploy/README.md">Deployment</a><br/>
-      <a href="{{ site.baseurl }}/api">Hub API</a>
-    </div>
   </div>
 </footer>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,8 +1,10 @@
 <div class="nav-section">
   <a href="{{ site.baseurl }}/about">About</a><br/>
   <a href="{{ site.baseurl }}/#updates">Updates</a><br/>
-  <a href="{{ site.baseurl }}/docs">Docs</a>{% unless site.public %}<br/>
-  <a href="{{ site.baseurl }}/private/docs">Private Docs</a>{% endunless %}
+  <a href="{{ site.baseurl }}/docs">Docs</a><br/>{% unless site.public %}
+  <a href="{{ site.baseurl }}/private/docs">Private Docs</a><br/>
+  <a href="https://github.com/18F/data-private/blob/master/README.md#how-to-update-this-data">Edit data</a><br/>{% endunless %}
+  <a href="{{ site.baseurl }}/api">API</a>
 </div>
 <div class="nav-section">
   <strong>Team</strong><br/>{% if site.data.team %}


### PR DESCRIPTION
Also, the links from the footer have been removed, since they're now all in "Hub Ops".

@leahbannon @meiqimichelle @afeld: Suggestions welcome, of course!

Here's what the nav bar looks like for the internal version:
![internal](https://cloud.githubusercontent.com/assets/301547/5669294/a2e21fa8-9744-11e4-8532-78b6b9a1e766.jpg)

And for the public version:
![public](https://cloud.githubusercontent.com/assets/301547/5669293/a2dbcc3e-9744-11e4-8019-c98d00c5b45e.jpg)

