### PR TITLE
Use correct rbenv on each deployment machine

### DIFF
--- a/deploy/fabfile.py
+++ b/deploy/fabfile.py
@@ -33,14 +33,23 @@ import fabric.api
 #   fab [command] --set instance=public"
 INSTANCE = fabric.api.env.get('instance', 'internal')
 
-BUNDLE_CMD = "/usr/local/rbenv/shims/bundle"
-BUILD_CMD = "%s && %s exec jekyll b" % (BUNDLE_CMD, BUNDLE_CMD)
-PUBLIC_BUILD_CMD = BUILD_CMD + " --config _config.yml,_config_public.yml"
+INTERNAL_BUNDLE_CMD = "/usr/local/rbenv/shims/bundle"
+PUBLIC_BUNDLE_CMD = "/opt/install/rbenv/shims/bundle"
+PUBLIC_CONFIG = " --config _config.yml,_config_public.yml"
+
+BUILD_CMD = "exec jekyll b"
+INTERNAL_BUILD_CMD = "%s && %s %s && %s %s %s" % (
+  INTERNAL_BUNDLE_CMD,
+  INTERNAL_BUNDLE_CMD, BUILD_CMD,
+  INTERNAL_BUNDLE_CMD, BUILD_CMD, PUBLIC_CONFIG)
+PUBLIC_BUILD_CMD = "%s && %s %s %s" % (
+  PUBLIC_BUNDLE_CMD,
+  PUBLIC_BUNDLE_CMD, BUILD_CMD, PUBLIC_CONFIG)
 
 SETTINGS = {
   'internal': {
     'host': '18f-hub', 'port': 4000, 'home': '/home/ubuntu',
-    'branch': 'master', 'cmd': '%s && %s' % (BUILD_CMD, PUBLIC_BUILD_CMD)
+    'branch': 'master', 'cmd': INTERNAL_BUILD_CMD
   },
   'submodules': {
     'host': '18f-hub', 'port': 4001, 'home': '/home/ubuntu',


### PR DESCRIPTION
Turns out 18f.gsa.gov has `rbenv` in a different place...also needed a ruby version update and hookshot re-installed. Either way, the `hookshot` tasks for automated Hub deployment are up and running on both hub.18f.us and 18f.gsa.gov, using this new `fabfile.py` setup.

cc: @afeld @gboone @konklone