### PR TITLE
Update public snippets and deployment notes

### DIFF
--- a/_data/public/snippets/v3/20141208.csv
+++ b/_data/public/snippets/v3/20141208.csv
@@ -25,7 +25,9 @@ Work on long-term product vision statement for DoL",
 Forked eRegs with the intent to adapt it to more fully load FEC regs.
 Started to chase down some bugs in eRegs.","Continue chasing down eRegs bugs and generally massaging it into parsing FEC regs more fully.
 Continue exploration of AOs and MURs and how they connect to each other and the regs."
-12/9/2014 14:21:32,Public,jackie,"FOIA
+12/9/2014 14:21:32,Public,jackie,"
+
+FOIA
 * Worked on and merged two PRs relating to reports data
 * Tickets created:
     * Clean up tickets on main FOIA repo
@@ -82,6 +84,8 @@ MISC
 - Code static committee page
 - Finish designing district page
 - Code style guide
+
+
 ### Other
 - Gov UI Component spike
 "

--- a/_data/public/snippets/v3/20141215.csv
+++ b/_data/public/snippets/v3/20141215.csv
@@ -70,7 +70,9 @@ Got DoL database hooked up to Alan's implementation of Jesse's wireframes",
 
 ### Other
 - Spike on components for GovUI"
-12/15/2014 23:30:18,Public,jackie,"General updates
+12/15/2014 23:30:18,Public,jackie,"
+
+General updates
 * User interview for FOIA
 * FOIA discussion on updating contacts
 * FOIA discussion on a look up key for multiple sources of data - unresolved

--- a/_data/public/snippets/v3/20141222.csv
+++ b/_data/public/snippets/v3/20141222.csv
@@ -37,7 +37,9 @@ Worked with DevOps on a small sprint on making our Packer-based Ubuntu process p
 Several productive team FOIA meetings on evaluating our goals and priorities.
 
 Led a meeting with the government-wide FOIA Task Force. Attended a team FOIA demo to FOIA officers from around the government.
-",Wrapping up FOIA tasks. Speaking with a reporter about the .gov domain list.
+","
+
+Wrapping up FOIA tasks. Speaking with a reporter about the .gov domain list."
 12/22/2014 14:38:14,Public,shawn,"- developed Hourglass labor price search prototype and basic visualizations
 - researched new schemes for the dashboard project status colors
 - created a [tool](https://github.com/shawnbot/dotgov-screenshots) to take screenshots of all of the [.gov domains](https://catalog.data.gov/dataset/gov-domains-api)

--- a/_data/public/snippets/v3/20150105.csv
+++ b/_data/public/snippets/v3/20150105.csv
@@ -39,8 +39,12 @@ Support v0.1 of DAP prototype "
 - finished the first [hourglass](https://github.com/18F/hourglass/) sprint with front-end fixes and automated test scaffolding
 - refactored the [.gov screenshots](https://github.com/shawnbot/dotgov-screenshots/tree/node-js) capture process using node and [PhantomJS](http://phantomjs.org/), eliminating the external url2png dependency",
 1/5/2015 20:18:49,Public,eric,"Worked on getting Sendak set up on my computer and in my head. Helped rewrite some documentation for it.
+
+
 Miscellaneous FOIA tasks, including finishing up the long overdue replies to FOIA officers we emailed in November.
-","Figuring out what what HTTPS resources and advice we can offer the rest of the federal government.
+","
+
+Figuring out what what HTTPS resources and advice we can offer the rest of the federal government.
 
 FOIA team planning and post-holiday catchup and refocusing."
 1/7/2015 9:02:53,Public,jackie,"#### 18F Training Fellows

--- a/_data/public/snippets/v3/20150112.csv
+++ b/_data/public/snippets/v3/20150112.csv
@@ -1,0 +1,72 @@
+Timestamp,Public,Username,Last week,This week
+1/12/2015 11:46:19,Public,mbland,"Hub:
+- Circulated Hub Ownership doc
+- Extracted [weekly_snippets](https://rubygems.org/gems/weekly_snippets)
+  ([#34](https://github.com/18F/hub/pull/34)) and
+  [team_hub](https://rubygems.org/gems/team_hub)
+  ([#50](https://github.com/18F/hub/pull/50),
+   [#52](https://github.com/18F/hub/pull/52)) gems
+  - Thanks to Alan deLevie for teaching me how to properly set up gems,
+    particularly when it comes to Travis CI and Code Climate integration
+- [Setup Travis CI](https://travis-ci.org/18F/hub)
+  ([#33](https://github.com/18F/hub/pull/33))
+- Improved data editing interface
+  ([data-private#16](https://github.com/18F/data-private/pull/16),
+   [#39](https://github.com/18F/hub/pull/39))
+- Info design session with Aidan Feldman and Michelle Hertzfeld (opened
+  [#40](https://github.com/18F/hub/issues/40),
+  [#41](https://github.com/18F/hub/issues/41),
+  [#42](https://github.com/18F/hub/issues/42),
+  [18f.gsa.gov#455](https://github.com/18F/18f.gsa.gov/issues/455))
+- ./go script to abstract development steps 
+  ([#51](https://github.com/18F/hub/pull/51))
+- automated deployment to internal instances
+  ([#36](https://github.com/18F/hub/pull/36),
+   [#37](https://github.com/18F/hub/pull/37))
+- Deprecated [data-public](https://github.com/18F/data-public) and triaged all
+  remaining [hub-original](https://github.com/18F/hub-original) issues
+- Chat with Jackie Kazil about Midas+Hub integration, Webmaker, etc.
+- Worked with Greg Boone on Dashboard data import
+- hash-joiner: filter-yaml-files executable
+  [#6](https://github.com/18F/hash-joiner/pull/6)
+
+Misc:
+- Documentation Working Group: weekly meeting","- Hub: finish recruiting owners; pick at extracting gems
+- Ramp up Practice department
+
+Carried over:
+- Grade 2014Q4 Objectives and Key Results; draft 2015Q1 OKRs
+- Study [USDS Playbook](https://playbook.cio.gov/) and
+  [TechFAR Handbook](https://playbook.cio.gov/techfar/)
+- Continue development of Practice Dev Team vision
+- Continue development of ""Unit Testing Perspectives"" doc
+- Draft Working Groups/Guild post"
+1/12/2015 11:57:29,Public,boone,"- Worked on and published blog posts
+- Added the `data-private` submodule to Dashboard
+- Worked with Mike on automated deployments for Hub
+- Began updating deploy script for Dashboard
+- With the 18f-site team, drew out design mandates from the affinity diagram","- Begin auditing content for 18f-site
+- Finish blogging guide and process
+- Publish the dub-subsetter post
+- Finish automated deployment and hub integration work for Dashboard"
+1/13/2015 4:02:14,Public,afeld,"* moved C2 configuration away from multiple generated files to environment variables (yay 12Factor!)
+* upgrading C2 to roadie-rails for CSS inlining in mail
+    * ended up contributing to roadie and roadie-rails
+* progress on OSS maintainer guidelines
+* collecting and organizing information to be moved into the Hub
+* experimenting with adding search to the Hub
+* investigated PaaS options for 18F to move to
+    * deployed C2 to Elastic Beanstalk as an experiment","* review PaaS options with the DevOps team
+* get search working in the Hub
+* demo C2 to NCR service center users
+* interviews
+* rethinking the C2 schema/endpoints"
+1/13/2015 10:39:40,Public,leah,"took over product management for USCIS ICAM (research project, read issues, support backlog grooming), conducted candidate interview, started working on about text & UX testing plan for analytics data release",
+1/13/2015 11:35:04,Public,gray,"* Building out the paid tier for /Developer Program.  
+* HTTPS policy brainstorming 
+* 3 Agency API consults ","* Planning We The People Developer Engagement
+* Planning February API Usability session
+* Continued outreach within 18F to ensure API consistency 
+* API meetup 
+* Feedback for OMB websites memo
+* 1 Agency API consult"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -83,8 +83,6 @@ $ ssh 18f-hub sudo service google_auth_proxy restart
 
 ### Preparing for automated deployment
 
-**NOTE:** _Automated deployment is not yet in-place for the production instance of the public Hub, but will be very soon._
-
 The automated deployment of the Hub is accomplished by:
 
 - cloning the Hub's GitHub repository on the deployment host to track a specific deployment branch;
@@ -216,4 +214,8 @@ The Hub-specific config, [/etc/nginx/vhosts/hub.conf](etc/nginx/vhosts/hub.conf)
 
 [GitHub Webhooks](https://help.github.com/articles/about-webhooks/) are requests that are delivered by GitHub to a URL of your choosing based upon certain repository events. The [Webhooks level up](https://github.com/blog/1778-webhooks-level-up) blog post gives a good high-level introduction, with pictures. The [Webhooks API docs](https://developer.github.com/webhooks/) go into greater detail; note the **Creating webhooks** and **Configuring your server** sections in the section guide on the right of the page.
 
-The [18F Hub](https://github.com/18F/hub) webhook ensures that updates to the internal Hub and staging instance of the public Hub are automatically deployed; automatic deployment of the production instance of the public Hub is forthcoming. The [data-private](https://github.com/18F/data-private) and [hub-pages-private](https://github.com/18F/hub-pages-private) webhooks ensure that changes to those repositories are propagated immediately to the internal Hub and staging instance of the public Hub.
+The [18F Hub](https://github.com/18F/hub) webhooks ensure that updates to the internal Hub, the staging instance of the public Hub, and the production instance of the public Hub are automatically deployed:
+- For the internal and staging Hubs, changes committed to the `master` branch are deployed immediately.
+- For the public Hub, [open a pull request to merge the `master` branch into `production-public` branch](https://github.com/18F/hub/compare/production-public...master). Merging the pull request will trigger the webhook that will initiate deployment.
+
+The [data-private](https://github.com/18F/data-private) and [hub-pages-private](https://github.com/18F/hub-pages-private) webhooks ensure that changes to those repositories are propagated immediately to the internal Hub and staging instance of the public Hub. Those changes will not appear in the production instance of the public Hub until they are merged into the `production-public` branch.


### PR DESCRIPTION
These snippets were imported with `_data/import-public-snippets.rb`, and `deploy/README.md` has been updated to reflect the now-live automated deployment scheme for the public Hub. The whitespace changes to the previous batches don't produce any change in the generated site.

Once this PR is merged, I'll send a PR to merge `master` into `production-public` using the link supplied in the **GitHub: Configure Webhooks** section of `deploy/README.md`. Once that's merged, there won't be a noticeable change to https://18f.gsa.gov/hub/, but there should be a successful automated deployment nonetheless.

cc: @afeld @gboone @konklone 