### PR TITLE
Prefix ./go script with ruby path, not bundle path

### DIFF
--- a/deploy/fabfile.py
+++ b/deploy/fabfile.py
@@ -33,24 +33,24 @@ import fabric.api
 #   fab [command] --set instance=public"
 INSTANCE = fabric.api.env.get('instance', 'internal')
 
-INTERNAL_BUNDLE_CMD = "/usr/local/rbenv/shims/bundle"
-PUBLIC_BUNDLE_CMD = "/opt/install/rbenv/shims/bundle"
+INTERNAL_RUBY_CMD = "/usr/local/rbenv/shims/ruby"
+PUBLIC_RUBY_CMD = "/opt/install/rbenv/shims/ruby"
 
 SETTINGS = {
   'internal': {
     'host': '18f-hub', 'port': 4000, 'home': '/home/ubuntu',
     'branch': 'master',
-    'cmd': "%s ./go deploy_internal " % INTERNAL_BUNDLE_CMD,
+    'cmd': "%s ./go deploy_internal " % INTERNAL_RUBY_CMD,
   },
   'submodules': {
     'host': '18f-hub', 'port': 4001, 'home': '/home/ubuntu',
     'branch': 'master',
-    'cmd': "%s ./go deploy_submodules " % INTERNAL_BUNDLE_CMD,
+    'cmd': "%s ./go deploy_submodules " % INTERNAL_RUBY_CMD,
   },
   'public': {
     'host': '18f-site', 'port': 4002, 'home': '/home/site/production',
     'branch': 'production-public',
-    'cmd': "%s ./go deploy_public " % PUBLIC_BUNDLE_CMD,
+    'cmd': "%s ./go deploy_public " % PUBLIC_RUBY_CMD,
   },
 }[INSTANCE]
 


### PR DESCRIPTION
@afeld @gboone A quick fix for the `./go` script deployment setup. Confirmed that it works on the internal Hub, and the new task is running on 18f.gsa.gov. When I push a new batch of public snippets (or maybe even locations!), that'll confirm that the Public Hub deployment is still operational.