### PR TITLE
temp_test_file_helper v0.0.2; AssignTeamMemberImagesTest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
       hash-joiner
       jekyll
       weekly_snippets
-    test_temp_file_helper (0.0.1)
+    test_temp_file_helper (0.0.2)
       rake (~> 10.0)
     thor (0.19.1)
     timers (4.0.1)

--- a/Rakefile
+++ b/Rakefile
@@ -6,10 +6,5 @@ Rake::TestTask.new do |t|
   t.test_files = FileList['_test/*test.rb']
 end
 
-TestTempFileHelper::SetupTestEnvironmentTask.new do |t|
-  t.base_dir = File.dirname __FILE__
-  t.tmp_dir = File.join '_test', 'tmp'
-end
-
 desc "Run HashJoiner tests"
 task :default => :test

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,4 @@
 require 'rake/testtask'
-require 'test_temp_file_helper/rake'
 
 Rake::TestTask.new do |t|
   t.libs << '_test'

--- a/_plugins/joiner.rb
+++ b/_plugins/joiner.rb
@@ -197,7 +197,7 @@ module Hub
       img_dir = site.config['team_img_dir']
       missing = File.join(img_dir, site.config['missing_team_member_img'])
 
-      site.data['team'].each do |name, member|
+      @data['team'].each do |name, member|
         img = File.join(img_dir, "#{name}.jpg")
 
         if (File.exists? File.join(base, img) or

--- a/_test/joiner_assign_team_member_images_test.rb
+++ b/_test/joiner_assign_team_member_images_test.rb
@@ -1,0 +1,66 @@
+# 18F Hub - Docs & connections between team members, projects, and skill sets
+#
+# Written in 2015 by Mike Bland (michael.bland@gsa.gov)
+# on behalf of the 18F team, part of the US General Services Administration:
+# https://18f.gsa.gov/
+#
+# To the extent possible under law, the author(s) have dedicated all copyright
+# and related and neighboring rights to this software to the public domain
+# worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication along
+# with this software. If not, see
+# <https://creativecommons.org/publicdomain/zero/1.0/>.
+#
+# @author Mike Bland (michael.bland@gsa.gov)
+
+require_relative "test_helper"
+require_relative "../_plugins/joiner"
+require_relative "site"
+
+require "minitest/autorun"
+require "test_temp_file_helper"
+
+module Hub
+  class AssignTeamMemberImagesTest < ::Minitest::Test
+    def setup
+      @temp_file_helper = ::TestTempFileHelper::TempFileHelper.new
+      @team_img_dir = File.join 'assets', 'images' ,'team'
+      @private_data_path = File.join '_data', 'private'
+      @missing_team_member_img = 'logo-18f.jpg'
+
+      @site = DummyTestSite.new(config:{
+        'source' => @temp_file_helper.tmpdir,
+        'team_img_dir' => @team_img_dir,
+        'private_data_path' => @private_data_path,
+        'missing_team_member_img' => @missing_team_member_img,
+      })
+
+      @member = {'name' => 'mbland'}
+      @member_image = "#{@member['name']}.jpg"
+      @site.data['team'] = {@member['name'] => @member}
+
+      @joiner = JoinerImpl.new @site
+    end
+
+    def test_member_without_image_file_gets_missing_team_member_img
+      @joiner.assign_team_member_images
+      assert_equal(File.join(@team_img_dir, @missing_team_member_img),
+        @member['image'])
+    end
+
+    def test_member_with_image_file
+      @temp_file_helper.mkfile(File.join @team_img_dir, @member_image)
+      @joiner.assign_team_member_images
+      assert_equal File.join(@team_img_dir, @member_image), @member['image']
+    end
+
+    def test_member_with_private_image_file
+      @temp_file_helper.mkfile(
+        File.join @private_data_path, @team_img_dir, @member_image)
+      @joiner.assign_team_member_images
+      assert_equal File.join(@team_img_dir, @member_image), @member['image']
+    end
+  end
+end
+

--- a/_test/private_assets_copy_directory_to_site_test.rb
+++ b/_test/private_assets_copy_directory_to_site_test.rb
@@ -24,14 +24,14 @@ require "test_temp_file_helper"
 module Hub
   class PrivateAssetsCopyDirectoryToSiteTest < ::Minitest::Test
     def setup
+      @temp_file_helper = ::TestTempFileHelper::TempFileHelper.new
       config = {
-        'source' => ENV['TEST_TMPDIR'],
+        'source' => @temp_file_helper.tmpdir,
         'private_data_path' => File.join('private_assets', 'private_images'),
       }
       @site = DummyTestSite.new(config: config)
       @site.static_files = []
       @source_dir = File.join('assets', 'images', 'team')
-      @temp_file_helper = ::TestTempFileHelper::TempFileHelper.new
     end
 
     def teardown

--- a/_test/private_assets_exists_test.rb
+++ b/_test/private_assets_exists_test.rb
@@ -24,13 +24,13 @@ require "test_temp_file_helper"
 module Hub
   class PrivateAssetsExistsTest < ::Minitest::Test
     def setup
+      @temp_file_helper = ::TestTempFileHelper::TempFileHelper.new
       config = {
-        'source' => ENV['TEST_TMPDIR'],
+        'source' => @temp_file_helper.tmpdir,
         'private_data_path' => 'private_assets',
       }
       @site = DummyTestSite.new(config: config)
       @testdir = File.join config['source'], config['private_data_path']
-      @temp_file_helper = ::TestTempFileHelper::TempFileHelper.new
       @temp_file_helper.mkdir @site.config['private_data_path']
     end
 


### PR DESCRIPTION
@afeld Another incremental refactoring PR. Note that if 18F/team_hub#1 goes in first, I can add a commit to remove the current `PrivateAssets` and replace it with that from `team_hub`.