### PR TITLE
Fix unordered list item styles across the site

### DIFF
--- a/assets/_sass/_hub.scss
+++ b/assets/_sass/_hub.scss
@@ -11,6 +11,22 @@
   }
 }
 
+// Site-wide styles
+//********************************************************
+ul {
+  list-style: disc inside none;
+
+  li {
+    margin-bottom: 0.25em;
+
+    ul {
+      li {
+        padding-left: 2em;
+      }
+    }
+  }
+}
+
 // News Template
 //********************************************************
 .news {
@@ -46,20 +62,6 @@
   h4 {
     margin-top: 0.5em;
     margin-bottom: 0.5em;
-  }
-
-  ul {
-    list-style: disc inside none;
-
-    li {
-      margin-bottom: 0.25em;
-
-      ul {
-        li {
-          padding-left: 2em;
-        }
-      }
-    }
   }
 }
 


### PR DESCRIPTION
These styles used to only affect snippets. It only affects the first two
nesting levels; my CSS knowledge is not sufficient to fix lists nested more
deeply.

@gboone This'll make the new internal publishing guidelines look more normal.