### PR TITLE
Update `./go deploy_submodules`

### DIFF
--- a/go
+++ b/go
@@ -105,10 +105,8 @@ end
 
 def deploy_submodules
   deploy([
-    'cd _data',
-    '/usr/local/rbenv/shims/ruby ./import-public.rb',
-    'cd ..',
-    'git add _data/private _data/public/ pages/private',
+    '/usr/local/rbenv/shims/ruby _data/import-public.rb',
+    'git add .',
     'git commit -m \'Private submodule update\'',
     'git push',
   ])


### PR DESCRIPTION
Now that the `_data/import-public.rb` script doesn't need to be run in the
current directory, we can remove the extra `cd` commands. Also, `git add .`
should cover the addition of all submodule updates and imported files.

cc: @afeld @gboone