### PR TITLE
Switches the content type on json files

### DIFF
--- a/_plugins/api.rb
+++ b/_plugins/api.rb
@@ -174,7 +174,7 @@ module Hub
     def self.generate_endpoint(site, endpoint, title, description, data)
       return if data.empty?
       api_endpoint = File.join('api', endpoint)
-      page = ::TeamHub::Page.generate(site, api_endpoint, 'index.html',
+      page = ::TeamHub::Page.generate(site, api_endpoint, 'api.json',
         'api.json', "API: #{title}")
       page.data['json'] = JSON.generate(data)
       return [endpoint, title, description]

--- a/deploy/ansible/roles/dev/templates/hub.conf.j2
+++ b/deploy/ansible/roles/dev/templates/hub.conf.j2
@@ -6,7 +6,7 @@ server {
   location / {
       ssi on;
       root   {{ hub_root }}/_site;
-      index  index.html;
+      index  index.html api.json;
       default_type text/html;
       set $authenticated_user "{{ authenticated_user }}";
 
@@ -17,7 +17,7 @@ server {
 
   location /hub {
       root   {{ hub_root }}/_site_public;
-      index  index.html;
+      index  index.html api.json;
       default_type text/html;
   }
 }

--- a/deploy/etc/nginx/vhosts/hub.conf
+++ b/deploy/etc/nginx/vhosts/hub.conf
@@ -77,14 +77,14 @@ server {
   location / {
       ssi on;
       root   /home/ubuntu/hub/_site;
-      index  index.html;
+      index  index.html api.json;
       default_type text/html;
       set $authenticated_user $http_x_forwarded_email;
   }
 
   location /hub {
       root   /home/ubuntu/hub/_site_public;
-      index  index.html;
+      index  index.html api.json;
       default_type text/html;
   }
 }


### PR DESCRIPTION
- Adds an entry for `api.json` as an index file on the nginx vhost (not sure if that will actually work, will try to test it locally)
- Switches the generated filename to api.json for api files