### PR TITLE
Adds basic subnav to team page

### DIFF
--- a/assets/_sass/_hub.scss
+++ b/assets/_sass/_hub.scss
@@ -106,6 +106,25 @@ ul li {
   }
 }
 
+.hub-page-subnav {
+float: left;
+margin-bottom: 20px;
+  li {
+    display: inline-block;
+    padding: 10px;
+    margin-right: 3px;
+    border: 1px solid #bbb;
+    &:hover, &:focus {
+      background-color: #eee;
+    }
+  }
+}
+
+.clear { //forgive me this trespass, for it is late and I have no time
+  clear:left;
+}
+
+
 .index-entry {
   margin-top: 1em;
   margin-bottom: 1em;

--- a/pages/team.html
+++ b/pages/team.html
@@ -2,8 +2,18 @@
 layout: bare
 permalink: /team/
 ---
-<h1>&lt; team /&gt;</h1>
-<br/>
-<p>{% assign members = site.data.team %}{{ members.size }} members:</p>
-<br/>
+<h1>Team</h1>
+
+<p>Sort by:</p>
+
+<ul class="hub-page-subnav">
+  <a href="{{ site.baseurl }}/snippets"><li>Snippets</li></a>
+  <a href="{{ site.baseurl }}/locations"><li>Location</li></a>
+  <a href="{{ site.baseurl }}/languages"><li>Language</li></a>
+  <a href="{{ site.baseurl }}/technologies"><li>Technology</li></a>
+  <a href="{{ site.baseurl }}/specialties"><li>Specialty</li></a>
+</ul>
+
+<p class="clear">{% assign members = site.data.team %}{{ members.size }} members:</p>
+
 {% include team_members.html %}


### PR DESCRIPTION
This adds a basic subnav to the team page that looks like this:
![screenshot 2015-02-05 21 52 53](https://cloud.githubusercontent.com/assets/4827522/6074690/65b3e12c-ad81-11e4-8d24-668b11a522a0.png)

I think is this a good solution to test with, and a good solution for the demo tomorrow.