### PR TITLE
Make an org chart

### DIFF
--- a/_data/org.yml
+++ b/_data/org.yml
@@ -1,0 +1,24 @@
+name: 18F
+teams:
+- name: Delivery
+  teams:
+  - name: Engineering
+  - name: Product
+  - name: Practice
+  - name: Senior Product Design
+  - name: Staff & Projects
+  - name: Team Administration
+- name: Creative, Communication & Community
+  teams:
+  - name: Outreach
+  - name: Experience Design
+    teams:
+    - name: UX Design
+    - name: Visual Design
+    - name: Front End Design
+    - name: Content Design
+- name: PIF & Digital Services Teams
+- name: DevOps
+- name: Business Operations & Personnel
+- name: Consulting
+- name: Hiring Operations

--- a/_plugins/api.rb
+++ b/_plugins/api.rb
@@ -31,6 +31,7 @@ module Hub
         generate_projects_endpoint(site),
         generate_departments_endpoint(site),
         generate_working_groups_endpoint(site),
+        generate_org_endpoint(site),
       ]
       endpoint_info.concat generate_skills_endpoints(site)
       endpoint_info = endpoint_info.select {|i| i and !i.empty?}
@@ -118,6 +119,13 @@ module Hub
       data = create_filtered_hash(wg, 'name', fields, join_fields)
       generate_endpoint(site, 'working_groups', 'Working Groups',
         'Working group info, indexed by name', data)
+    end
+
+    def self.generate_org_endpoint(site)
+      org = site.data['org']
+      return if !org or org.empty?
+      generate_endpoint(site, 'org', 'Organization',
+        'Org chart, organized by team', org)
     end
 
     # Generates an endpoint for each skill category and returns a list of


### PR DESCRIPTION
:construction: **WIP** :construction:

This PR introduces a new `org.yml` and `org` API endpoint that describes the 18F team structure.

First off, I could use some feedback on the YAML structure. It's a tree composed of "teams" with 18F at the root. I haven't added people to this yet, but my thinking was that we could designate team leads by adding `lead: <id>` to a team and a `members` list to each if we want to get fancy.

Then, if we decide to go down the route of putting people in here, we can talk about how best to do that in the API endpoint. I started trying to hack in a recursive function that would populate `members` lists, but I have zero Ruby experience and got hung up pretty quickly.

Next up, I'm going to work on some really basic HTML output for this on structure page.