### PR TITLE
pages_api_test: clearly report site build failure

### DIFF
--- a/_test/pages_api_test.rb
+++ b/_test/pages_api_test.rb
@@ -23,7 +23,12 @@ module Hub
     # before all
     # TODO isolate the tests better
     BUILD_DIR = File.join(Dir.pwd, '_test', 'tmp')
-    `bundle exec jekyll build --destination #{BUILD_DIR}`
+    unless system(
+      "bundle exec jekyll build --destination #{BUILD_DIR} --trace",
+      {:out => '/dev/null', :err =>STDERR})
+      STDERR.puts "\n***\nSite failed to build for pages_api_test\n***\n"
+      exit $?.exitstatus
+    end
     PATH = File.join(BUILD_DIR, 'api', 'v1', 'pages.json')
 
     def read_json(path)


### PR DESCRIPTION
Before this change, a `jekyll build` failure results in assertion failures in `pages_api_test`. With this change, build errors are now clearly apparent, and no additional tests are run. Tested this by deliberately introducing a build failure, and switching back again.

cc: @afeld