### PR TITLE
Updated alts on team page

### DIFF
--- a/_includes/team_members.html
+++ b/_includes/team_members.html
@@ -1,7 +1,7 @@
 <div class="team-members">{% for member in members %}
   <div class="team-member">
     <div class="team-member-cell">
-      <a href="{{ site.baseurl }}/team/{{ member.name }}"><img class="team-member-thumb" src="{{ site.baseurl }}/{{ member.image }}" alt="Thumbnail photo of {{ member.full_name }}"></a>
+      <a href="{{ site.baseurl }}/team/{{ member.name }}"><img class="team-member-thumb" src="{{ site.baseurl }}/{{ member.image }}" alt="{% if member.image == 'assets/images/team/logo-18f.jpg' %}18F logo, {{ member.full_name }} photo missing{% else %}{{ member.full_name }}{% endif %}"></a>
     </div>
     <div class="team-member-info">
       <a href="{{ site.baseurl }}/team/{{ member.name }}">{{ member.full_name }}</a>{% if member.location %} - <a href="{{ site.baseurl }}/locations/{{ member.location }}">{{ member.location }}</a><br/>{% endif %}

--- a/_includes/team_members.html
+++ b/_includes/team_members.html
@@ -1,7 +1,8 @@
 <div class="team-members">{% for member in members %}
   <div class="team-member">
     <div class="team-member-cell">
-      <a href="{{ site.baseurl }}/team/{{ member.name }}"><img class="team-member-thumb" src="{{ site.baseurl }}/{{ member.image }}" alt="{% if member.image == 'assets/images/team/logo-18f.jpg' %}18F logo, {{ member.full_name }} photo missing{% else %}{{ member.full_name }}{% endif %}"></a>
+      {% capture img_basename %}{{ member.image | split:"/" | last }}{% endcapture %}
+      <a href="{{ site.baseurl }}/team/{{ member.name }}"><img class="team-member-thumb" src="{{ site.baseurl }}/{{ member.image }}" alt="{% if img_basename == site.missing_team_member_img %}18F logo, {{ member.full_name }} photo missing{% else %}{{ member.full_name }}{% endif %}"></a>
     </div>
     <div class="team-member-info">
       <a href="{{ site.baseurl }}/team/{{ member.name }}">{{ member.full_name }}</a>{% if member.location %} - <a href="{{ site.baseurl }}/locations/{{ member.location }}">{{ member.location }}</a><br/>{% endif %}


### PR DESCRIPTION
Removed 'thumbnail photo of' this information is redundant to a SR user. 

Also, added check for 18f logo and alternate text. 