### PR TITLE
Use split-file version of _data/private if present

### DIFF
--- a/_plugins/joiner.rb
+++ b/_plugins/joiner.rb
@@ -122,7 +122,19 @@ module Hub
 
       # We'll always need a 'team' property.
       @join_source['team'] ||= []
+      ['team', 'projects', 'departments', 'working_groups'].each do |c|
+        i = @join_source[c]
+        @join_source[c] = JoinerImpl.flatten_index(i) if i.instance_of? Hash
+      end
       create_team_by_email_index
+    end
+
+    # Takes Hash<string, Array<Hash>> collections and flattens them
+    # Array<Hash>.
+    def self.flatten_index(index)
+      private_data = index['private']
+      index['private'] = {'private' => private_data.values} if private_data
+      index.values
     end
 
     # Joins team member data, converts site.data[team] to a hash of

--- a/_test/joiner_flatten_index_test.rb
+++ b/_test/joiner_flatten_index_test.rb
@@ -1,0 +1,55 @@
+# 18F Hub - Docs & connections between team members, projects, and skill sets
+#
+# Written in 2015 by Mike Bland (michael.bland@gsa.gov)
+# on behalf of the 18F team, part of the US General Services Administration:
+# https://18f.gsa.gov/
+#
+# To the extent possible under law, the author(s) have dedicated all copyright
+# and related and neighboring rights to this software to the public domain
+# worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication along
+# with this software. If not, see
+# <https://creativecommons.org/publicdomain/zero/1.0/>.
+#
+# @author Mike Bland (michael.bland@gsa.gov)
+
+require_relative "test_helper"
+require_relative "../_plugins/joiner"
+
+require "minitest/autorun"
+
+module Hub
+  class FlattenIndexTest < ::Minitest::Test
+    def test_empty_index
+      assert_empty JoinerImpl.flatten_index({})
+    end
+
+    def test_index
+      orig = {
+        'mbland' => {'name' => 'mbland'},
+        'afeld' => {'name' => 'afeld'},
+        'mhz' => {'name' => 'mhz'},
+      }
+      assert_equal(
+        [{'name' => 'mbland'}, {'name' => 'afeld'}, {'name' => 'mhz' }],
+        JoinerImpl.flatten_index(orig))
+    end
+
+    def test_index_with_private_values
+      orig = {
+        'mbland' => {'name' => 'mbland'},
+        'afeld' => {'name' => 'afeld'},
+        'mhz' => {'name' => 'mhz'},
+        'private' => {
+          'gboone' => {'name' => 'gboone'},
+          'ekamlley' => {'name' => 'ekamlley'},
+        },
+      }
+      assert_equal(
+        [{'name' => 'mbland'}, {'name' => 'afeld'}, {'name' => 'mhz' },
+         {'private' => [{'name' => 'gboone'}, {'name' => 'ekamlley'}]}],
+        JoinerImpl.flatten_index(orig))
+    end
+  end
+end


### PR DESCRIPTION
This is safe to commit before the switch is made in data-private.

The point here is to transform the split files from Hash<String, Array<Hash>> into the Array<Hash> format expected by the existing plugin logic. Note that the submodule commit is pointing at the `split-files` branch within `data-private`. It might be worth extracting the plugin logic and incorporating it into 18f.gsa.gov and the Dashboard before switching `data-private:master` over to the split-file version, as this would guarantee every system could parse both the original and the split-file `data-private`.

cc: @gboone @meiqimichelle @afeld @elainekamlley @brethauer 
