### PR TITLE
Canonicalize project names

### DIFF
--- a/_includes/team_members.html
+++ b/_includes/team_members.html
@@ -9,7 +9,7 @@
       <a class="location" href="{{ site.baseurl }}/locations/{{ member.location }}">{{ member.location }}</a><br/>{% endif %}
       {% if member.projects and member.projects.length != 0 %}
       <p>
-        Projects: {% for p in member.projects %}<a href="{{ site.baseurl }}/projects/{{ p.name }}">{{ p.project }}</a>{% unless forloop.last %}, {% endunless %}{% endfor %}
+        Projects: {% for p in member.projects %}<a href="{{ site.baseurl }}/projects/{{ p.name | canonicalize }}">{{ p.project }}</a>{% unless forloop.last %}, {% endunless %}{% endfor %}
       </p>
       {% endif %}
     </div>

--- a/_layouts/team_member.html
+++ b/_layouts/team_member.html
@@ -12,7 +12,7 @@ layout: bare
 </p>
 {% if member.projects %}
 <h2>Projects</h2>{% for proj in member.projects %}
-<a href="{{ site.baseurl }}/projects/{{ proj.name }}">{{ proj.project }}</a><br/>{% endfor %}
+<a href="{{ site.baseurl }}/projects/{{ proj.name | canonicalize }}">{{ proj.project }}</a><br/>{% endfor %}
 {% endif %}
 {% if member.working_groups %}
 <h2>Working Groups</h2>

--- a/pages/projects.html
+++ b/pages/projects.html
@@ -6,7 +6,7 @@ permalink: projects/
 
 {% for proj in site.data.projects %}
 <div class="index-entry">
-	<h2><a href="{{ site.baseurl }}/projects/{{ proj.name }}">{{ proj.project }}</a></h2>
+	<h2><a href="{{ site.baseurl }}/projects/{{ proj.name | canonicalize }}">{{ proj.project }}</a></h2>
 	<p>{% if proj.description %}{{ proj.description }}{% endif %}</p>
 	<p>{% if proj.team %}{% assign member_separator = ', ' %}{% assign members = proj.team %}Team: {% include team_members_short.html %}{% endif %}</p>
 </div>


### PR DESCRIPTION
Just noticed that links to the Common Acquisition Platform Tools project, "C2", were broken.

cc: @meiqimichelle 