### PR TITLE
Add testing cookbook link

### DIFF
--- a/pages/guidelines.html
+++ b/pages/guidelines.html
@@ -8,6 +8,7 @@ permalink: guidelines/
 	<li><a href="https://github.com/18F/open-source-policy">Open Source Policy</a></li>
 	<li><a href="https://github.com/18F/api-standards">18F API Standards</a></li>
 	<li><a href="https://github.com/18F/frontend-style-guide">18F Frontend Styleguide</a></li>
+	<li><a href="https://github.com/18F/testing-cookbook/">18F Testing Cookbook</a></li>
 {% unless site.public %}
 	<li><a href="https://docs.google.com/a/gsa.gov/document/d/16ozBoXxTnWutvp63mr5Q8phN21IRFD3LYm3BtgYkQg0/edit">18F Guide to Distributed Work</a></li>
 	<li><a href="{{ site.baseurl }}/private/devops/standards/slack/">18F Slack Guidelines</a></li>


### PR DESCRIPTION
This started with @meiqimichelle suggesting that I add a link to my [VirtualBox guide](https://github.com/18F/testing-cookbook/blob/master/browser/VirtualBox.md) to the hub. But I figured that linking to the testing cookbook more generally would probably be better. Thoughts on where this goes, @mbland?