### PR TITLE
Export more project data via the API

### DIFF
--- a/_plugins/api.rb
+++ b/_plugins/api.rb
@@ -93,9 +93,9 @@ module Hub
 
     def self.generate_projects_endpoint(site)
       projects = site.data['projects']
-      return if !projects or projects.empty?
-      fields = ['project', 'github', 'partner', 'impact', 'stage',
-        'milestones', 'contact', 'stack', 'licenses', 'links', 'status']
+      fields = ['project', 'github', 'description', 'partner', 'partners',
+        'impact', 'stage', 'milestones', 'contact', 'stack', 'licenselink',
+        'licenses', 'links', 'blog', 'status']
       join_fields = {'team' => 'name'}
       data = create_filtered_hash(projects, 'name', fields, join_fields)
       generate_endpoint(site, 'projects', 'Projects',


### PR DESCRIPTION
This is a step towards using the public Hub API as the data source for 18f.gsa.gov and the Dashboard.

cc: @gboone @shawnbot @afeld @meiqimichelle 