### PR TITLE
show bullets for lists

### DIFF
--- a/assets/_sass/_hub.scss
+++ b/assets/_sass/_hub.scss
@@ -88,7 +88,7 @@ div.skip-nav a {
     position: absolute;
     top: 5px;
     left: 5px;
-    width: auto; 
+    width: auto;
     height: auto;
     z-index: 999999;
     padding-left: 2px;
@@ -143,10 +143,6 @@ a:focus {
 }
 a:focus img{
   border: 2px solid red;
-}
-
-ul li {
-  list-style-type: none;
 }
 
 .hub-page-section {
@@ -221,16 +217,16 @@ margin-bottom: 20px;
    color: #777678;
 }
 
-:-moz-placeholder { 
-   color: #777678;  
+:-moz-placeholder {
+   color: #777678;
 }
 
 ::-moz-placeholder {
-   color: #777678;  
+   color: #777678;
 }
 
-:-ms-input-placeholder {  
-   color: #777678;  
+:-ms-input-placeholder {
+   color: #777678;
 }
 
 // Snippets

--- a/assets/_sass/base/_lists.scss
+++ b/assets/_sass/base/_lists.scss
@@ -1,7 +1,6 @@
 ul, ol {
   margin: 0;
   padding: 0;
-  list-style-type: none;
 
   &%default-ul {
     list-style-type: disc;


### PR DESCRIPTION
Guessing they were taken out intentionally, but I think the text is easier to read with them in.

**Before**

![screen shot 2015-03-05 at 11 42 52 am](https://cloud.githubusercontent.com/assets/86842/6509358/d0e6b6b6-c32c-11e4-950a-86477e8df88c.png)

**After**

![screen shot 2015-03-05 at 11 39 45 am](https://cloud.githubusercontent.com/assets/86842/6509364/d7c1e366-c32c-11e4-9428-c46673b2e84f.png)

I looked through a handful of changes to make sure they weren't showing up where they're not supposed to (e.g. the team page or the nav bar), but possible I missed something.

/cc @meiqimichelle 