### PR TITLE
Fix fixit page permalinks

### DIFF
--- a/pages/fixit/guides/participation.md
+++ b/pages/fixit/guides/participation.md
@@ -1,5 +1,5 @@
 ---
-permalink: /fixit/guides/participation
+permalink: /fixit/guides/participation/
 ---
 
 # Fixit Participation Guide

--- a/pages/fixit/guides/planning.md
+++ b/pages/fixit/guides/planning.md
@@ -1,5 +1,5 @@
 ---
-permalink: /fixit/guides/planning
+permalink: /fixit/guides/planning/
 ---
 
 # Planning a Fixit

--- a/pages/fixit/onboarding.md
+++ b/pages/fixit/onboarding.md
@@ -1,5 +1,5 @@
 ---
-permalink: /fixit/onboarding
+permalink: /fixit/onboarding/
 ---
 # Onboarding Fixit
 


### PR DESCRIPTION
Whoops, missed that the permalinks must end with a trailing slash in the front matter. Just posting this as an FYI; will merge myself.

cc: @bsweger @gboone 