### PR TITLE
use new Jekyll 3 beta numbering scheme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '3.0.0.beta2'
+gem 'jekyll', '3.0.0.pre.beta2'
 gem 'redcarpet'
 gem 'RedCloth'
 gem 'bourbon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
     htmlentities (4.3.3)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
-    jekyll (3.0.0.beta2)
+    jekyll (3.0.0.pre.beta2)
       colorator (~> 0.1)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
@@ -123,7 +123,7 @@ DEPENDENCIES
   codeclimate-test-reporter
   coveralls
   hash-joiner
-  jekyll (= 3.0.0.beta2)
+  jekyll (= 3.0.0.pre.beta2)
   jekyll-assets
   jekyll-sitemap
   jekyll_pages_api

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
     domain_name (0.5.23)
       unf (>= 0.0.5, < 1.0.0)
     execjs (2.4.0)
-    ffi (1.9.6)
+    ffi (1.9.8)
     hash-joiner (0.0.7)
       safe_yaml
     hike (1.2.3)
@@ -45,7 +45,7 @@ GEM
       sprockets-sass
     jekyll-sass-converter (1.3.0)
       sass (~> 3.2)
-    jekyll-sitemap (0.8.0)
+    jekyll-sitemap (0.8.1)
     jekyll-watch (1.2.1)
       listen (~> 2.7)
     jekyll_pages_api (0.1.1)
@@ -56,7 +56,7 @@ GEM
     liquid (3.0.1)
     liquid_pluralize (1.0.2)
       liquid (>= 2.6, < 4.0)
-    listen (2.8.5)
+    listen (2.9.0)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)


### PR DESCRIPTION
I guess they changed their version naming scheme?

https://rubygems.org/gems/jekyll

Same Jekyll code, but updated some other gems. Fixes the build.