### PR TITLE
flesh out fixit participation guide

### DIFF
--- a/pages/docsprint/guides/participation.md
+++ b/pages/docsprint/guides/participation.md
@@ -4,4 +4,37 @@ permalink: /docsprint/guides/participation/
 
 # Doc Sprint Participation Guide
 
-Here will be a guide to participating in a doc sprint.
+Taking our documentation to the next level is critical for scaling 18F. Here are some helpful materials and resources for participating in a doc sprint.
+
+## You Will Need
+To participate in an 18F doc sprint, you will need:
+
+* A [GitHub account](https://help.github.com/articles/signing-up-for-a-new-github-account/) with [two-factor authentication enabled](https://help.github.com/articles/about-two-factor-authentication/)
+
+## Ways to Contribute
+Each doc sprint will have a specific to-do list. You can participate by:
+
+* Creating or updating documentation on the to-do list.
+* Suggesting new documentation. The method for making a suggestion will depend on the project, but might be a GitHub issue or a Trello task.
+* Giving feedback about documentation that others are creating during the doc sprint. This kind of conversation usually happens in a GitHub issue.
+* Testing documentation created by others. For example, trying to stand up a local version of a project by following the directions in its README file.
+
+
+## Tools
+
+### Markdown
+
+Most 18F documentation is written in Markdown, a text-to-HTML conversion tool. Markdown is pretty straightforward.
+
+* Base [Markdown syntax](http://daringfireball.net/projects/markdown/).
+* For documentation hosted on GitHub, note that [GitHub-flavored markdown is in effect](https://help.github.com/articles/github-flavored-markdown/). It's very similar to regular Markdown but has some slight differences as well as some extra features like syntax highlighting.
+
+### Git and GitHub
+
+A large amount of 18F documentation is managed via git repositories. These are hosted on GitHub, which makes it easier to edit the Markdown documents. GitHub also provides tools for opening and tracking issues and submitting changes (called _pull requests_).
+
+If you're not familiar with Git and GitHub, these resources can get you started. You definitely don't need to be a git power user, and you can always ask questions in the #git Slack channel.
+
+* Edit GitHub documents online using prose.io (for projects that use it) [insert link to Mel's prose.io doc]
+* [How to Use GitHub and the Terminal: A Guide](https://18f.gsa.gov/2015/03/03/how-to-use-github-and-the-terminal-a-guide/)
+* [Mastering GitHub Issues](https://guides.github.com/features/issues/)

--- a/pages/docsprint/guides/participation.md
+++ b/pages/docsprint/guides/participation.md
@@ -6,35 +6,49 @@ permalink: /docsprint/guides/participation/
 
 Taking our documentation to the next level is critical for scaling 18F. Here are some helpful materials and resources for participating in a doc sprint.
 
-## You Will Need
+## <a name="todo"></a>Event Specific To-Do Lists
+
+Specific information and to-do list for each doc sprint:
+
+* [April 17 Onboarding Doc Sprint](../../onboarding/)
+
+## For All Doc Sprints
+
+### You Will Need
 To participate in an 18F doc sprint, you will need:
 
 * A [GitHub account](https://help.github.com/articles/signing-up-for-a-new-github-account/) with [two-factor authentication enabled](https://help.github.com/articles/about-two-factor-authentication/)
 
-## Ways to Contribute
-Each doc sprint will have a specific to-do list. You can participate by:
+### Ways to Contribute
+Each doc sprint will have a specific [to-do](#todo) list. You can participate by:
 
 * Creating or updating documentation on the to-do list.
 * Suggesting new documentation. The method for making a suggestion will depend on the project, but might be a GitHub issue or a Trello task.
 * Giving feedback about documentation that others are creating during the doc sprint. This kind of conversation usually happens in a GitHub issue.
 * Testing documentation created by others. For example, trying to stand up a local version of a project by following the directions in its README file.
 
+### Tools
 
-## Tools
-
-### Markdown
+#### Markdown
 
 Most 18F documentation is written in Markdown, a text-to-HTML conversion tool. Markdown is pretty straightforward.
 
 * Base [Markdown syntax](http://daringfireball.net/projects/markdown/).
 * For documentation hosted on GitHub, note that [GitHub-flavored markdown is in effect](https://help.github.com/articles/github-flavored-markdown/). It's very similar to regular Markdown but has some slight differences as well as some extra features like syntax highlighting.
 
-### Git and GitHub
+#### Git and GitHub
 
 A large amount of 18F documentation is managed via git repositories. These are hosted on GitHub, which makes it easier to edit the Markdown documents. GitHub also provides tools for opening and tracking issues and submitting changes (called _pull requests_).
 
-If you're not familiar with Git and GitHub, these resources can get you started. You definitely don't need to be a git power user, and you can always ask questions in the #git Slack channel.
+If you're not familiar with Git and GitHub, these resources can get you started. You definitely don't need to be a git power user, and you can always ask questions in the `#git` Slack channel.
 
 * Edit GitHub documents online using prose.io (for projects that use it) [insert link to Mel's prose.io doc]
 * [How to Use GitHub and the Terminal: A Guide](https://18f.gsa.gov/2015/03/03/how-to-use-github-and-the-terminal-a-guide/)
 * [Mastering GitHub Issues](https://guides.github.com/features/issues/)
+
+#### Slack
+
+If you have questions about doc sprints, the documenation working group is happy to help. You can find us on Slack:
+
+* `#wg-documentation`: questions about the Hub and doc sprint events
+* `#questions`: triage point for other questions that come up during the doc sprint

--- a/pages/docsprint/onboarding.md
+++ b/pages/docsprint/onboarding.md
@@ -5,13 +5,15 @@ permalink: /docsprint/onboarding/
 
 ## tl;dr
 
-A lot of new people are starting at 18F on April 6th. Do these things to get ready for them:
+A lot of new people are getting ready to start at 18F. Do these things to prepare for them:
 
 1. **Every project**: [update project READMEs](#repo).
 2. Update the [18F Onboarding Guide](https://hub.18f.us/private/18f-site/onboarding/).
 3. Update our [18F Guides](http://18f.github.io/guides/).
 
-This cohort will test our documentation as they onboard. On April 17th, we sprint and implement their suggestions for improvement. Getting our docs right is a key part of scaling 18F's onboarding process.
+This cohort will test our documentation as they onboard.
+
+[April 17th](#sprint): we sprint and improve our onboarding docs to prepare for the next cohort.
 
 # Why?
 
@@ -63,9 +65,13 @@ Make sure your project has a Hub page and that it contains the following informa
 
 Our new coworkers onboard using the materials we've created. We all use this opportunity to record opportunities for improvement. The specific feedback mechanisms will likely be project-specific (*e.g.*, GitHub issue, Trello card). In addition, doc sprint organizers will survey the new cohort to get additional ideas.
 
-### Doc Sprint Day: April 17th
+### <a name="sprint"></a>Doc Sprint Day: April 17th
 
-We'll congregate to tackle the collected issues (and create new ones if necessary), reporting along the way. We'll use a Google form to track what gets done. This tracking is a critical step, since we want to collect doc sprint metrics.
+1. Here's a list of things you can work on during the April 17th doc sprint.
+    * [Hub issues](https://github.com/18F/hub/issues)
+    * [18F Guide issues](https://github.com/18F/guides/issues)
+
+2. After you complete a task, please log it using our [doc sprint form](#) so we can report on what got done.
 
 ### Post-Doc Sprint
 

--- a/pages/docsprint/onboarding.md
+++ b/pages/docsprint/onboarding.md
@@ -3,6 +3,18 @@ permalink: /docsprint/onboarding/
 ---
 # Onboarding Doc Sprint
 
+## tl;dr
+
+A lot of new people are starting at 18F on April 6th. Do these things to get ready for them:
+
+1. **Every project**: [update project READMEs](#repo).
+2. Update the [18F Onboarding Guide](https://hub.18f.us/private/18f-site/onboarding/).
+3. Update our [18F Guides](http://18f.github.io/guides/).
+
+This cohort will test our documentation as they onboard. On April 17th, we sprint and implement their suggestions for improvement. Getting our docs right is a key part of scaling 18F's onboarding process.
+
+# Why?
+
 The theme for 18F's first official [doc sprint](/docsprint) is onboarding. The **Onboarding+Doc Sprint** will culminate on April 17th, 2015.
 
 The ops and onboarding teams are doing tremendous work to make sure new hires have the best possible transition to life at 18F.
@@ -19,7 +31,7 @@ A large cohort is starting at 18F on April 6th, and these new teammates are the 
 
 Project teams and working groups get their onboarding houses in order. At a minimum, the documentation for each project should contain the following information:
 
-#### In Project Repository
+#### <a name="repo"></a>In Project Repository
 
 Make sure README.md has:
 
@@ -53,7 +65,7 @@ Our new coworkers onboard using the materials we've created. We all use this opp
 
 ### Doc Sprint Day: April 17th
 
-We'll congregate to tackle the collected issues (and create new ones if necessary), reporting along the way. We'll likely use a Google form to track what gets done. This tracking is a critical step, since we want to collect doc sprint metrics.
+We'll congregate to tackle the collected issues (and create new ones if necessary), reporting along the way. We'll use a Google form to track what gets done. This tracking is a critical step, since we want to collect doc sprint metrics.
 
 ### Post-Doc Sprint
 


### PR DESCRIPTION
Starting to flesh out the participation guide. @melodykramer I left a placeholder for the prose.io doc. I also heard that you volunteered to write more, and I had some ideas when drafting this. Some of these could also be useful to incorporate into our NDoCH plans.

* Some kind of visual or doc on overall git/GitHub workflow as it pertains to written docs. Some of this is in the GitHub command-line blog that you and Greg wrote, but it might be helpful to show the workflow independent of the tool (command line vs GitHub client vs GitHub website)
* Speaking of the various git/GitHub editing tools, should we list the options somewhere? Or just pick one and make a recommendation for new users?
* You wrote a great GitHub prose.io guide. Do we also need a guide to editing docs via the GitHub website for projects that don't use prose?
* Do we need to extricate a stand-alone git explainer from the GitHub command-line blog so it's available to people who choose not to use the command line?