### PR TITLE
Embed access token as Javascript variable via SSI

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -89,7 +89,8 @@
 <script>
 // export some helpful site-wide variables
 window.site = {
-  baseurl: "{{ site.baseurl }}"
+  baseurl: "{{ site.baseurl }}"{% unless site.public %},
+  access_token: "<!--# echo var="access_token" -->"{% endunless %}
 };
 </script>
 

--- a/deploy/etc/nginx/vhosts/hub.conf
+++ b/deploy/etc/nginx/vhosts/hub.conf
@@ -80,6 +80,7 @@ server {
       index  index.html api.json;
       default_type text/html;
       set $authenticated_user $http_x_forwarded_email;
+      set $access_token $http_x_forwarded_access_token;
   }
 
   location /hub {


### PR DESCRIPTION
The motivation for this is to pass the authenticated user's MyUSA access token
through so that Javascript can be used to request Midas data per #211. More
generally, this should allow us to integrate other backend services that
accept MyUSA access tokens. (Care must be taken, of course, to ensure that
tokens are sent only over secure connetions.)

The upstream auth proxy will pass the OAuth `access_token` into the Hub server
via the `X-Forwarded-Access-Token` HTTP header. We then use the Nginx `set`
directive to rewrite this header's value as the `access_token` variable, which
then gets assigned to a Javascript variable via the `#echo` Server-Side
Include directive.

cc: @dhcole @afeld @adelevie @yozlet @jackiekazil