### PR TITLE
Fixes #254, Cleaned up Guidelines Links

### DIFF
--- a/pages/guidelines.md
+++ b/pages/guidelines.md
@@ -7,18 +7,18 @@ published: true
 # Guidelines
 
 * [Open Source Policy](https://github.com/18F/open-source-policy)
-* [18F API Standards](https://github.com/18F/api-standards)
-* [18F Frontend Styleguide](https://github.com/18F/frontend-style-guide)
+* [API Standards](https://github.com/18F/api-standards)
+* [Frontend Styleguide](https://github.com/18F/frontend-style-guide)
 {% unless site.public %}
-* [18F Guide to Distributed Work](https://docs.google.com/a/gsa.gov/document/d/16ozBoXxTnWutvp63mr5Q8phN21IRFD3LYm3BtgYkQg0/edit)
-* [18F Slack Guidelines]({{ site.baseurl }}/private/devops/standards/slack/)
+* [Distributed Work Guide](https://docs.google.com/a/gsa.gov/document/d/16ozBoXxTnWutvp63mr5Q8phN21IRFD3LYm3BtgYkQg0/edit)
+* [Slack Guidelines]({{ site.baseurl }}/private/devops/standards/slack/)
 * [Github Standards]({{ site.baseurl }}/private/devops/standards/github/)
-* [18F Security Guidelines]({{ site.baseurl }}/private/devops/standards/security/)
-* [The Use of AWS at 18F]({{ site.baseurl }}/private/devops/standards/aws/)
-* [18F Terms and Conditions]({{ site.baseurl }}/private/devops/standards/terms-and-conditions/)
-* [How 18F Manages Client Accounts](https://docs.google.com/a/gsa.gov/document/d/1PIgWhoAifBmx6K-ihh8h9HRPQz1Mlj0TKHWv-UNWE-4/)
-* [Using Ubuntu at 18F]({{ site.baseurl }}/private/team-ops/ubuntu/)
-* [How to hold events at 18F]({{ site.baseurl }}/private/team-ops/resources/event-info/)
+* [Security Guidelines]({{ site.baseurl }}/private/devops/standards/security/)
+* [Use of AWS]({{ site.baseurl }}/private/devops/standards/aws/)
+* [Terms and Conditions]({{ site.baseurl }}/private/devops/standards/terms-and-conditions/)
+* [How We Manage Client Accounts](https://docs.google.com/a/gsa.gov/document/d/1PIgWhoAifBmx6K-ihh8h9HRPQz1Mlj0TKHWv-UNWE-4/)
+* [Using Ubuntu]({{ site.baseurl }}/private/team-ops/ubuntu/)
+* [How to hold events]({{ site.baseurl }}/private/team-ops/resources/event-info/)
 * [Publishing and Content Submission on 18f.gsa.gov]({{ site.baseurl }}/private/18F-site/publishing/)
 {% endunless %}
 


### PR DESCRIPTION
- Removes noise
- Places most relevant info at beginning of link, wherever possible
- Avoids gratuitous use of "18F"