### PR TITLE
simplify 4/17

### DIFF
--- a/pages/docsprint/onboarding.md
+++ b/pages/docsprint/onboarding.md
@@ -1,87 +1,16 @@
 ---
 permalink: /docsprint/onboarding/
 published: true
-title: Untitled
+title: Onboarding Doc Sprint
 ---
 
 # Onboarding Doc Sprint
 
-## tl;dr
+On April 17th, we've carved out some time to focus on fixing and creating 18F documentation related to onboarding.
 
-A lot of new people are getting ready to start at 18F. Do these things to prepare for them:
-
-1. **Every project**: [update project READMEs](#repo).
-2. Create an onboarding guide for your team. (You can use the [18F website team's as a model](https://hub.18f.us/private/18f-site/onboarding/).)
-3. Update our [18F Guides](http://18f.github.io/guides/).
-
-This cohort will test our documentation as they onboard.
-
-[April 17th](#sprint): we sprint and improve our onboarding docs to prepare for the next cohort.
-
-# Why?
-
-The theme for 18F's first official [doc sprint](/docsprint) is onboarding. The **Onboarding+Doc Sprint** will culminate on April 17th, 2015.
-
-The ops and onboarding teams are doing tremendous work to make sure new hires have the best possible transition to life at 18F.
-
-There's additional work to do, however, and a key component involves making sure our individual teams and working groups are ready to absorb the upcoming influx of new hires. Also, as the Hub becomes integral to onboarding, we need to make sure the information there is correct and useful.
-
-The onboarding process is more than documentation, but documentation is critical to making sure onboarding can scale.
-
-## The Plan
-
-A large cohort is starting at 18F on April 6th, and these new teammates are the incentive for the onboarding doc sprint. Here's an outline of our thinking.
-
-### Before April 6th
-
-Project teams and working groups get their onboarding houses in order. At a minimum, the documentation for each project should contain the following information:
-
-#### <a name="repo"></a>In Project Repository
-
-Make sure README.md has:
-
-* A link to an existing public instance of the project. Links to internal/staging versions can be listed on the Hub (see below) if you don't want them publicly visible.
-* Description of the workflow for submitting project code changes (_e.g._ do you fork or branch?)
-* How to stand up a development version of the project. Installation commands, scripts, a Vagrantfile for forced fresh install, etc.
-* Project management-related information:
-
-    * Links to GitHub issues, sprint plans, dashboards, etc.
-    * Links to task management tools (GitHub, Trello, Pivotal Tracker)
-    * Quick write-up of where things are: GitHub issues versus sprint plans
-
-Also consider:
-
-* Updating the CONTRIBUTING file to reflect the workflow as written in README.md.
-* Tagging issues as new-to-project.
-
-#### On the Hub
-
-Make sure your project has a Hub page and that it contains the following information:
-
-* Daily standup time and location
-* Sprint plan days/time/location
-* Point of contact for project's calendar invites
-* Links to internal/staging versions of the project, if applicable
-
-
-### April 6th - April 16th
-
-Our new coworkers onboard using the materials we've created. We all use this opportunity to record opportunities for improvement. The specific feedback mechanisms will likely be project-specific (*e.g.*, GitHub issue, Trello card). In addition, doc sprint organizers will survey the new cohort to get additional ideas.
-
-### <a name="sprint"></a>Doc Sprint Day: April 17th
-
-1. Here's a list of things you can work on during the April 17th doc sprint.
+1. Here's a list of things to work on:
     * [Hub issues](https://github.com/18F/hub/issues)
     * [18F Guide issues](https://github.com/18F/guides/issues)
+    
 
-2. After you complete a task, please log it using our [doc sprint form](#) so we can report on what got done.
-
-### Post-Doc Sprint
-
-The doc sprint organizers will survey participants, sift through the collected metrics, and report back:
-
-* How many people participated?
-* What did the doc sprint help accomplish for individuals, projects, working groups, and guilds?
-* How many issues did we fix?
-* What is now possible after the doc sprint that wasn't possible before?
-* What should we do differently in the next doc sprint?
+2. After you complete a task, please log it here so we can report on what got done: [https://docs.google.com/a/gsa.gov/spreadsheets/d/1lrA_ovE_LkNkqm1vXvk25jJeI5ETOuU0dKMRxZM63Ac/edit#gid=0](https://docs.google.com/a/gsa.gov/spreadsheets/d/1lrA_ovE_LkNkqm1vXvk25jJeI5ETOuU0dKMRxZM63Ac/edit#gid=0)


### PR DESCRIPTION
Too little, too late, and if I had to do it again, I'd simplify or eliminate the entire structure of pages around the doc sprint, but at the very least let's remove the bunch of text around today's event and add a link to a very simple google doc in case we want to capture what we'll be working on.

The to-do list isn't great, so feel free to add to it, if you'd like. At this point, thought, I think we're all just planning to work through our own Hub-related punch lists.
