### PR TITLE
Enable searches longer than nine characters

### DIFF
--- a/assets/js/vendor/angular-livesearch/liveSearch.js
+++ b/assets/js/vendor/angular-livesearch/liveSearch.js
@@ -94,7 +94,7 @@ angular.module("LiveSearch", ["ng"])
                 var vals = target.val().split(",");
                 var search_string = vals[vals.length - 1].trim();
                 // Do Search
-                if (search_string.length < 3 || search_string.length > 9) {
+                if (search_string.length < 3) {
                     scope.visible = false;
                     //unmanaged code needs to force apply
                     scope.$apply();


### PR DESCRIPTION
Addresses #119, #226, and #255. The "correct" fix is pending resolution of mauriciogentile/angular-livesearch#7, but this gets us a much more usable search in the short-term. The next angular-livesearch release imported into the Hub should contain a permanent fix for the issue.

@afeld or @vzvenyach, mind merging this?

cc: @adelevie