### PR TITLE
removing standards from guidelines pages

### DIFF
--- a/pages/guidelines.md
+++ b/pages/guidelines.md
@@ -11,11 +11,6 @@ published: true
 * [Frontend Styleguide](https://github.com/18F/frontend-style-guide){% unless site.public %}
 * [Leave, Telework, and Virtual Worker Policy]({{ site.baseurl }}/private/team-ops/leave-telework-virtual-worker-policy/)
 * [Distributed Work Guide](https://docs.google.com/a/gsa.gov/document/d/16ozBoXxTnWutvp63mr5Q8phN21IRFD3LYm3BtgYkQg0/edit)
-* [Slack Guidelines]({{ site.baseurl }}/private/devops/standards/slack/)
-* [Github Standards]({{ site.baseurl }}/private/devops/standards/github/)
-* [Security Guidelines]({{ site.baseurl }}/private/devops/standards/security/)
-* [Use of AWS]({{ site.baseurl }}/private/devops/standards/aws/)
-* [Terms and Conditions]({{ site.baseurl }}/private/devops/standards/terms-and-conditions/)
 * [How We Manage Client Accounts](https://docs.google.com/a/gsa.gov/document/d/1PIgWhoAifBmx6K-ihh8h9HRPQz1Mlj0TKHWv-UNWE-4/)
 * [Using Ubuntu]({{ site.baseurl }}/private/team-ops/ubuntu/)
 * [How to hold events]({{ site.baseurl }}/private/team-ops/resources/event-info/)


### PR DESCRIPTION
Standards are different from guidelines. I think we'll re-address this as part of the redesign in #269 