### PR TITLE
Add tests for untitled posts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ _site_public
 .vagrant
 _test/tmp
 bower_components
+coverage/*

--- a/_test/pages_api_test.rb
+++ b/_test/pages_api_test.rb
@@ -49,6 +49,14 @@ module Hub
       homepage_data['body']
     end
 
+    def posts_with_empty_titles
+      entries_data.select { |hash| hash['title'] == '' }
+    end
+
+    def posts_with_title_called_untitled
+      entries_data.select { |hash| hash['title'] == 'Untitled' }
+    end
+
     def test_files_exist
       assert(File.exist?(PATH), "JSON file doesn't exist.")
     end
@@ -59,6 +67,14 @@ module Hub
 
     def test_inserts_content
       assert_includes(homepage_body, 'Team information')
+    end
+
+    def test_all_posts_have_titles
+      assert_empty posts_with_empty_titles.map { |hash| hash['url'] }
+    end
+
+    def test_no_posts_are_untitled
+      assert_empty posts_with_title_called_untitled.map { |hash| hash['url'] }
     end
   end
 end


### PR DESCRIPTION
I added two new tests that check for empty post titles and titles that are literally set to "Untitled". The failure error will show you an array of URLs for posts that don't have titles.

I also added the coverage folder to `.gitignore` since it doesn't look like it's in the GitHub repo.