### PR TITLE
Ship a url-to-doc map for search, not pages.json

### DIFF
--- a/_plugins/search.js
+++ b/_plugins/search.js
@@ -6,3 +6,10 @@ var index = lunr(function() {
   this.field('url', {boost: 5});
   this.field('body');
 });
+
+var url_to_doc = {};
+
+corpus.entries.forEach(function(page) {
+  index.add(page);
+  url_to_doc[page.url] = {url: page.url, title: page.title};
+});

--- a/_plugins/search.rb
+++ b/_plugins/search.rb
@@ -11,14 +11,27 @@ module Hub
         'assets', 'js', 'vendor', 'lunr.js', 'lunr.js'))
       cxt.load(File.join(site.source, '_plugins', 'search.js'))
       cxt.eval("var corpus = #{corpus_page.content};")
-      cxt.eval('corpus.entries.forEach(function(page) {index.add(page);});')
+      cxt.eval("var url_to_doc = {};")
+      cxt.eval(
+        'corpus.entries.forEach(function(page) {' +
+        '  index.add(page);' +
+        '  url_to_doc[page.url] = {url: page.url, title: page.title};' +
+        '});')
 
       index_page = JekyllPagesApi::PageWithoutAFile.new(
         site, site.source, '', 'index.json')
       index_page.content = cxt.eval("JSON.stringify(index.toJSON());")
-      index_page.data['layout'] = nil
-      index_page.render(Hash.new, site.site_payload)
-      index_page
+
+      url_to_doc_page = JekyllPagesApi::PageWithoutAFile.new(
+        site, site.source, '', 'url_to_doc.json')
+      url_to_doc_page.content = cxt.eval("JSON.stringify(url_to_doc);")
+
+      pages = [index_page, url_to_doc_page]
+      pages.each do |page|
+        page.data['layout'] = nil
+        page.render(Hash.new, site.site_payload)
+      end
+      return pages
     end
 
     def self.find_corpus_page(pages)

--- a/_plugins/search.rb
+++ b/_plugins/search.rb
@@ -4,19 +4,13 @@ module Hub
   class SearchIndexBuilder
     def self.build_index(site)
       corpus_page = find_corpus_page(site.pages)
-      return nil if corpus_page == nil
+      raise 'Pages API corpus not found' if corpus_page == nil
 
       cxt = V8::Context.new
       cxt.load(File.join(site.source,
         'assets', 'js', 'vendor', 'lunr.js', 'lunr.js'))
-      cxt.load(File.join(site.source, '_plugins', 'search.js'))
       cxt.eval("var corpus = #{corpus_page.content};")
-      cxt.eval("var url_to_doc = {};")
-      cxt.eval(
-        'corpus.entries.forEach(function(page) {' +
-        '  index.add(page);' +
-        '  url_to_doc[page.url] = {url: page.url, title: page.title};' +
-        '});')
+      cxt.load(File.join(site.source, '_plugins', 'search.js'))
 
       index_page = JekyllPagesApi::PageWithoutAFile.new(
         site, site.source, '', 'index.json')

--- a/_plugins/search_hook.rb
+++ b/_plugins/search_hook.rb
@@ -12,9 +12,8 @@ module Jekyll
     def after_render
       pages_api_after_render
       return if self.config['skip_index']
-      index, url_to_doc = Hub::SearchIndexBuilder.build_index(self)
-      self.pages << index if index != nil
-      self.pages << url_to_doc if url_to_doc != nil
+      search_pages = Hub::SearchIndexBuilder.build_index(self)
+      self.pages.concat search_pages
     end
   end
 end

--- a/_plugins/search_hook.rb
+++ b/_plugins/search_hook.rb
@@ -12,8 +12,9 @@ module Jekyll
     def after_render
       pages_api_after_render
       return if self.config['skip_index']
-      index = Hub::SearchIndexBuilder.build_index(self)
+      index, url_to_doc = Hub::SearchIndexBuilder.build_index(self)
       self.pages << index if index != nil
+      self.pages << url_to_doc if url_to_doc != nil
     end
   end
 end

--- a/_test/search_test.rb
+++ b/_test/search_test.rb
@@ -9,5 +9,10 @@ module Hub
       assert(File.exist?(File.join(SiteBuilder::BUILD_DIR, 'index.json')),
         "Serialized lunr.js index doesn't exist")
     end
+
+    def test_url_to_doc_map_built
+      assert(File.exist?(File.join(SiteBuilder::BUILD_DIR, 'url_to_doc.json')),
+        "Serialized URL-to-doc info index doesn't exist")
+    end
   end
 end

--- a/_test/search_test.rb
+++ b/_test/search_test.rb
@@ -1,18 +1,41 @@
 require_relative 'test_helper'
 require_relative 'site_builder'
 
+require 'json'
 require 'minitest/autorun'
 
 module Hub
   class SearchTest < ::Minitest::Test
     def test_index_built
-      assert(File.exist?(File.join(SiteBuilder::BUILD_DIR, 'index.json')),
-        "Serialized lunr.js index doesn't exist")
+      index_file = File.join(SiteBuilder::BUILD_DIR, 'index.json')
+      assert(File.exist?(index_file), "Serialized lunr.js index doesn't exist")
+
+      File.open(index_file, 'r') do |f|
+        index = JSON.parse f.read, :max_nesting => 200
+        refute_empty index
+        refute_nil index['corpusTokens']
+        refute_nil index['documentStore']
+        refute_nil index['fields']
+        refute_nil index['pipeline']
+        refute_nil index['ref']
+        refute_nil index['tokenStore']
+        refute_nil index['version']
+      end
     end
 
     def test_url_to_doc_map_built
-      assert(File.exist?(File.join(SiteBuilder::BUILD_DIR, 'url_to_doc.json')),
+      url_to_doc_file = File.join(SiteBuilder::BUILD_DIR, 'url_to_doc.json')
+      assert(File.exist?(url_to_doc_file),
         "Serialized URL-to-doc info index doesn't exist")
+      File.open(url_to_doc_file, 'r') do |f|
+        url_to_doc = JSON.parse f.read
+        refute_empty url_to_doc
+        url_to_doc.each do |k,v|
+          refute_nil v['url']
+          refute_nil v['title']
+          assert_equal k, v['url']
+        end
+      end
     end
   end
 end

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,9 +1,9 @@
 define(['angularAMD', 'liveSearch', 'lunr'], function(angularAMD, liveSearch, lunr) {
   var ngHub = angular.module('hubSearch', ['LiveSearch']);
 
-  ngHub.factory('pagesPromise', ["$http", "$q", function($http, $q) {
-    return $http.get(SITE_BASEURL + '/api/v1/pages.json').then(function(response) {
-      return response.data.entries;
+  ngHub.factory('pagesByUrlPromise', ["$http", "$q", function($http, $q) {
+    return $http.get(SITE_BASEURL + '/url_to_doc.json').then(function(response) {
+      return response.data;
     });
   }]);
 
@@ -14,17 +14,15 @@ define(['angularAMD', 'liveSearch', 'lunr'], function(angularAMD, liveSearch, lu
   }]);
 
 
-  ngHub.factory('pagesByUrl', ["pagesPromise", function(pagesPromise) {
-    var result = {};
+  ngHub.factory('pagesByUrl', ["pagesByUrlPromise", function(pagesByUrlPromise) {
+    var container = {};
 
     // populate asynchronously
-    pagesPromise.then(function(docs) {
-      angular.forEach(docs, function(doc) {
-        result[doc.url] = doc;
-      });
+    pagesByUrlPromise.then(function(url_to_doc_json) {
+      container['index'] = url_to_doc_json;
     });
 
-    return result;
+    return container;
   }]);
 
   ngHub.factory('pageIndex', ["pageIndexPromise", function(pageIndexPromise) {
@@ -39,7 +37,7 @@ define(['angularAMD', 'liveSearch', 'lunr'], function(angularAMD, liveSearch, lu
     return function(term) {
       var results = pageIndex.index.search(term);
       angular.forEach(results, function(result) {
-        var page = pagesByUrl[result.ref];
+        var page = pagesByUrl.index[result.ref];
         result.page = page;
         // make top-level attribute available for LiveSearch
         result.displayTitle = page.title || page.url;


### PR DESCRIPTION
Size comparison:
$ ls -l _site/api/v1/pages.json _site/url_to_doc.json
-rw-r--r--  1 _  _  675772 May  1 15:34 _site/api/v1/pages.json
-rw-r--r--  1 _  _   50932 May  1 15:34 _site/url_to_doc.json

$ python -c 'print "%0.2f%%" % ((50932 / 675772.0) * 100)'
7.54%

cc: @afeld @dhcole 