### PR TITLE
Consolidate lunr.js index and url-to-doc mapping

### DIFF
--- a/_plugins/search.js
+++ b/_plugins/search.js
@@ -13,3 +13,8 @@ corpus.entries.forEach(function(page) {
   index.add(page);
   url_to_doc[page.url] = {url: page.url, title: page.title};
 });
+
+var result = JSON.stringify({
+  index: index.toJSON(),
+  url_to_doc: url_to_doc
+});

--- a/_plugins/search.rb
+++ b/_plugins/search.rb
@@ -13,19 +13,11 @@ module Hub
       cxt.load(File.join(site.source, '_plugins', 'search.js'))
 
       index_page = JekyllPagesApi::PageWithoutAFile.new(
-        site, site.source, '', 'index.json')
-      index_page.content = cxt.eval("JSON.stringify(index.toJSON());")
-
-      url_to_doc_page = JekyllPagesApi::PageWithoutAFile.new(
-        site, site.source, '', 'url_to_doc.json')
-      url_to_doc_page.content = cxt.eval("JSON.stringify(url_to_doc);")
-
-      pages = [index_page, url_to_doc_page]
-      pages.each do |page|
-        page.data['layout'] = nil
-        page.render(Hash.new, site.site_payload)
-      end
-      return pages
+        site, site.source, '', 'search-index.json')
+      index_page.content = cxt[:result]
+      index_page.data['layout'] = nil
+      index_page.render(Hash.new, site.site_payload)
+      return index_page
     end
 
     def self.find_corpus_page(pages)

--- a/_plugins/search_hook.rb
+++ b/_plugins/search_hook.rb
@@ -12,8 +12,7 @@ module Jekyll
     def after_render
       pages_api_after_render
       return if self.config['skip_index']
-      search_pages = Hub::SearchIndexBuilder.build_index(self)
-      self.pages.concat search_pages
+      self.pages << Hub::SearchIndexBuilder.build_index(self)
     end
   end
 end

--- a/_test/search_test.rb
+++ b/_test/search_test.rb
@@ -7,11 +7,14 @@ require 'minitest/autorun'
 module Hub
   class SearchTest < ::Minitest::Test
     def test_index_built
-      index_file = File.join(SiteBuilder::BUILD_DIR, 'index.json')
-      assert(File.exist?(index_file), "Serialized lunr.js index doesn't exist")
+      index_file = File.join(SiteBuilder::BUILD_DIR, 'search-index.json')
+      assert(File.exist?(index_file), "Serialized search index doesn't exist")
 
       File.open(index_file, 'r') do |f|
-        index = JSON.parse f.read, :max_nesting => 200
+        search_index = JSON.parse f.read, :max_nesting => 200
+        refute_empty search_index
+
+        index = search_index['index']
         refute_empty index
         refute_nil index['corpusTokens']
         refute_nil index['documentStore']
@@ -20,15 +23,8 @@ module Hub
         refute_nil index['ref']
         refute_nil index['tokenStore']
         refute_nil index['version']
-      end
-    end
 
-    def test_url_to_doc_map_built
-      url_to_doc_file = File.join(SiteBuilder::BUILD_DIR, 'url_to_doc.json')
-      assert(File.exist?(url_to_doc_file),
-        "Serialized URL-to-doc info index doesn't exist")
-      File.open(url_to_doc_file, 'r') do |f|
-        url_to_doc = JSON.parse f.read
+        url_to_doc = search_index['url_to_doc']
         refute_empty url_to_doc
         url_to_doc.each do |k,v|
           refute_nil v['url']

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,43 +1,27 @@
 define(['angularAMD', 'liveSearch', 'lunr'], function(angularAMD, liveSearch, lunr) {
   var ngHub = angular.module('hubSearch', ['LiveSearch']);
 
-  ngHub.factory('pagesByUrlPromise', ["$http", "$q", function($http, $q) {
-    return $http.get(SITE_BASEURL + '/url_to_doc.json').then(function(response) {
-      return response.data;
-    });
-  }]);
-
-  ngHub.factory('pageIndexPromise', ["$http", "$q", function($http, $q) {
-    return $http.get(SITE_BASEURL + '/index.json').then(function(response) {
+  ngHub.factory('searchIndexPromise', ["$http", "$q", function($http, $q) {
+    return $http.get(SITE_BASEURL + '/search-index.json').then(function(response) {
       return response.data;
     });
   }]);
 
 
-  ngHub.factory('pagesByUrl', ["pagesByUrlPromise", function(pagesByUrlPromise) {
+  ngHub.factory('searchIndex', ["searchIndexPromise", function(searchIndexPromise) {
     var container = {};
-
-    // populate asynchronously
-    pagesByUrlPromise.then(function(url_to_doc_json) {
-      container['index'] = url_to_doc_json;
-    });
-
-    return container;
-  }]);
-
-  ngHub.factory('pageIndex', ["pageIndexPromise", function(pageIndexPromise) {
-    var container = {};
-    pageIndexPromise.then(function(index_json) {
-      container['index'] = lunr.Index.load(index_json);
+    searchIndexPromise.then(function(index_json) {
+      container.url_to_doc = index_json.url_to_doc;
+      container.index = lunr.Index.load(index_json.index);
     });
     return container;
   }]);
 
-  ngHub.factory('pagesSearch', ["pagesByUrl", "pageIndex", function(pagesByUrl, pageIndex) {
+  ngHub.factory('pagesSearch', ["searchIndex", function(searchIndex) {
     return function(term) {
-      var results = pageIndex.index.search(term);
+      var results = searchIndex.index.search(term);
       angular.forEach(results, function(result) {
-        var page = pagesByUrl.index[result.ref];
+        var page = searchIndex.url_to_doc[result.ref];
         result.page = page;
         // make top-level attribute available for LiveSearch
         result.displayTitle = page.title || page.url;


### PR DESCRIPTION
This isn't a slam-dunk in terms of performance, but eliminates one HTTP request and simplifies the code.

In terms of the performance impact of #279, check these times against those from #278:

**Before this change:**
![split-timeline](https://cloud.githubusercontent.com/assets/301547/7442923/98260124-f0f4-11e4-9ab6-63724714bd73.png)
![split-network](https://cloud.githubusercontent.com/assets/301547/7442925/a8fb6b7e-f0f4-11e4-8b53-2472704e1327.png)

**After this change:**
![consolidated-timeline](https://cloud.githubusercontent.com/assets/301547/7442926/b0cc6902-f0f4-11e4-91fc-92ddb67a254a.png)
![consolidated-network](https://cloud.githubusercontent.com/assets/301547/7442927/b59260ae-f0f4-11e4-806c-17952f59818b.png)

cc: @afeld 