### PR TITLE
Deploy public Hub including Javascript fixes

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -39,7 +39,7 @@
 </script>
 
 <!-- Browser warning, console message -->
-<script src="{{ site.baseurl }}{% asset_path 18f.js %}"></script>
+<script src="{% asset_path 18f.js %}"></script>
 
 {% for script_url in page.scripts %}
 {% unless script_url contains '.min.js' %}
@@ -47,4 +47,4 @@
 {% else %}<script src="{{ site.baseurl }}{{ script_url }}"></script>{% endunless %}
 {% endfor %}
 
-<script async data-main="{{ site.baseurl }}/assets/js/main" src="{{ site.baseurl }}{% asset_path vendor/requirejs/require %}"></script>
+<script async data-main="{{ site.baseurl }}/assets/js/main" src="{% asset_path vendor/requirejs/require %}"></script>


### PR DESCRIPTION
@gboone I just noticed that the search was broken on the public Hub. Was a very quick fix; going to go ahead and merge this myself to get things working.

Also, there's no webhook listener configured for https://18f.gsa.gov/hub/deploy. We should fix that.