### PR TITLE
Adds a margin and alternate styling for nested ols

### DIFF
--- a/assets/_sass/_hub.scss
+++ b/assets/_sass/_hub.scss
@@ -29,6 +29,19 @@ ul {
   }
 }
 
+ol {
+  list-style-type: decimal;
+  li {
+    ol {
+      list-style-type: lower-alpha;
+      li {
+        margin-left: 2em;
+        padding-right: 2em;
+      }
+    }
+  }
+}
+
 .nav {
   float: left;
   width: 100%;


### PR DESCRIPTION
To match the nesting spacing on `ul` elements, this properly nests `ol`s on the hub and styles them with the `roman-alpha` list type.