### PR TITLE
Redirect from *.18f.us to *.18f.gov

### DIFF
--- a/deploy/etc/nginx/vhosts/hub.conf
+++ b/deploy/etc/nginx/vhosts/hub.conf
@@ -6,16 +6,16 @@
 # HTTP server
 server {
   listen 80;
-  server_name  hub.18f.*;
-  return 301 https://hub.18f.gov$request_uri;
+  server_name  ~^(?<vhost>[^.]+)\.18f\.*;
+  return 301 https://$vhost.18f.gov$request_uri;
 }
 
 # HTTPS server (with SPDY enabled)
 server {
   listen 443 ssl spdy;
-  server_name  hub.18f.us;
+  server_name  ~^(?<vhost>[^.]+)\.18f\.us;
   include ssl/star.18f.us.conf;
-  return 301 https://hub.18f.gov$request_uri;
+  return 301 https://$vhost.18f.gov$request_uri;
 }
 
 server {


### PR DESCRIPTION
Closes 18F/tock#124.

Already running in production.

cc: @seanherron @jpyuda 