### PR TITLE
Enable Nginx's gzip_static option

### DIFF
--- a/deploy/etc/nginx/nginx.conf
+++ b/deploy/etc/nginx/nginx.conf
@@ -50,6 +50,7 @@ http {
   ##
 
   gzip on;
+  gzip_static on;
   gzip_disable "msie6";
   gzip_vary on;
   gzip_types  text/plain text/css application/x-javascript text/xml application/xml application/xml+rss text/javascript application/rss+xml application/json application/javascript;


### PR DESCRIPTION
More info: http://nginx.org/en/docs/http/ngx_http_gzip_static_module.html

I just rebuilt Nginx using version 1.8.0 and `--with-http_gzip_static_module` enabled. This is in anticipation of using the [jekyll_pages_api_search gem](https://github.com/18F/jekyll_pages_api_search/), which uses gzip to compress the code bundle and the search corpus at build time.

@gboone and @konklone I've rebuilt and restarted Nginx on 18f.gsa.gov as well, and will be sending a config PR shortly. I'll merge this one myself.