### PR TITLE
Move new-to-18F links to top of nav lists

### DIFF
--- a/_includes/nav-main.html
+++ b/_includes/nav-main.html
@@ -3,6 +3,17 @@
     <a href="{{ site.baseurl }}/">
       <img src="{{ site.baseurl }}/assets/images/18f-logo-small.png" alt="18F logo">
     </a>
+    {% unless site.public %}
+    <li>
+      <a href="{{ site.baseurl }}/n00b">New to 18F?</a>
+    </li>
+    <li>
+      <a href="{{ site.baseurl }}/how-to">How to...</a>
+    </li>
+    <li>
+      <a href="{{ site.baseurl }}/structure">18F Structure</a>
+    </li>
+    {% endunless %}
     <li>
       <a href="{{ site.baseurl }}/team">Team</a>
     </li>
@@ -12,21 +23,10 @@
     <li>
       <a href="{{ site.baseurl }}/guidelines">Guidelines</a>
     </li>
-    {% unless site.public %}
-    <li>
-      <a href="{{ site.baseurl }}/structure">18F Structure</a>
-    </li>
-    <li>
-      <a href="{{ site.baseurl }}/how-to">How to...</a>
-    </li>
-    {% endunless %}
     <li>
       <a href="{{ site.baseurl }}/about">About the Hub</a>
     </li>
     {% unless site.public %}
-    <li>
-      <a href="{{ site.baseurl }}/n00b">New to 18F?</a>
-    </li>
     {% endunless %}
   </ul>
 </nav>

--- a/pages/index.html
+++ b/pages/index.html
@@ -17,20 +17,20 @@ title: Home
 
   <div>
   <ul class="main-nav">
+    <li><a href="{{ site.baseurl }}/n00b/">New to 18F?</a>
+      Start your journey here, n00b.
+    </li>
+    <li><a href="{{ site.baseurl }}/how-to/">How to...</a>
+      A collection of FAQs about life at 18F.
+    </li>
+    <li><a href="https://pages.18f.gov/guides/">Guides</a>
+      Learn best practices employed by 18F.
+    </li>
     <li><a href="{{ site.baseurl }}/team/">Team</a>
       Learn something about the 18F team.
     </li>
     <li><a href="{{ site.baseurl }}/projects/">Projects</a>
       Learn something about 18F projects.
-    </li>
-    <li><a href="https://pages.18f.gov/guides/">Guides</a>
-      Learn best practices employed by 18F.
-    </li>
-    <li><a href="{{ site.baseurl }}/how-to/">How to...</a>
-      A collection of FAQs about life at 18F.
-    </li>
-    <li><a href="{{ site.baseurl }}/n00b/">New to 18F?</a>
-      Start your journey here, n00b.
     </li>
   </ul>
   </div>


### PR DESCRIPTION
This tries to address the issue of new hires missing the "n00b" sections of the Hub without having them pointed out explicitly.

cc: @meiqimichelle @colinpmacarthur @brethauer 

![n00b-move](https://cloud.githubusercontent.com/assets/301547/8010442/38c3492c-0b7e-11e5-9c55-fb0b20675e2b.png)
