### PR TITLE
Update gems, but lock down redcarpet at 3.2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'jekyll', '3.0.0.pre.beta2'
-gem 'redcarpet'
+gem 'redcarpet', '3.2.3'
 gem 'RedCloth'
 gem 'bourbon'
 gem 'jekyll-sitemap'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'jekyll', '3.0.0.pre.beta2'
-gem 'redcarpet', '3.2.3'
+gem 'redcarpet', '3.2.3' # avoiding https://github.com/vmg/redcarpet/issues/494
 gem 'RedCloth'
 gem 'bourbon'
 gem 'jekyll-sitemap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,14 +48,14 @@ GEM
     jekyll-sitemap (0.8.1)
     jekyll-watch (1.2.1)
       listen (~> 2.7)
-    jekyll_pages_api (0.1.3)
+    jekyll_pages_api (0.1.4)
       htmlentities (~> 4.3)
       jekyll (>= 2.0, < 4.0)
-    jekyll_pages_api_search (0.1.0)
-      jekyll_pages_api (~> 0.1.3)
+    jekyll_pages_api_search (0.2.0)
+      jekyll_pages_api (~> 0.1.4)
       sass (~> 3.4)
       therubyracer (~> 0.12.2)
-    json (1.8.2)
+    json (1.8.3)
     kramdown (1.7.0)
     libv8 (3.16.14.7)
     liquid (3.0.3)
@@ -68,7 +68,7 @@ GEM
     mercenary (0.3.5)
     mime-types (2.6.1)
     minitest (5.7.0)
-    multi_json (1.11.0)
+    multi_json (1.11.1)
     netrc (0.10.3)
     rack (1.6.1)
     rake (10.4.2)
@@ -140,9 +140,12 @@ DEPENDENCIES
   liquid_pluralize
   minitest
   rake
-  redcarpet
+  redcarpet (= 3.2.3)
   rouge
   team_hub
   test_temp_file_helper
   uglifier
   weekly_snippets
+
+BUNDLED WITH
+   1.10.3


### PR DESCRIPTION
Turns out redcarpet 3.3.1 causes intermittent null pointer segfaults. See also: vmg/redcarpet#494

Example output:

```
$ ./go serve
Configuration file: /Users/michaelbland/src/18F/hub/_config.yml
            Source: /Users/michaelbland/src/18F/hub
       Destination: /Users/michaelbland/src/18F/hub/_site
 Incremental build: disabled
      Generating...
/usr/local/var/rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/jekyll-3.0.0.pre.beta2/lib/jekyll.rb:154:
[BUG] Segmentation fault at 0x000000000e0000
ruby 2.2.0p0 (2014-12-25 revision 49005) [x86_64-darwin14]

-- Crash Report log information --------------------------------------------
[...snip...]
```

cc: @afeld @msecret @maya @gboone @dhcole 