### PR TITLE
Fix search by upgrading to v0.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
     jekyll_pages_api (0.1.4)
       htmlentities (~> 4.3)
       jekyll (>= 2.0, < 4.0)
-    jekyll_pages_api_search (0.2.0)
+    jekyll_pages_api_search (0.2.1)
       jekyll_pages_api (~> 0.1.4)
       sass (~> 3.4)
       therubyracer (~> 0.12.2)
@@ -146,3 +146,6 @@ DEPENDENCIES
   test_temp_file_helper
   uglifier
   weekly_snippets
+
+BUNDLED WITH
+   1.10.3


### PR DESCRIPTION
This will allow search to work on the Hub again. v0.2.0 of the `jekyll_pages_api_search` gem had a packaging error that caused the `assets/js/search-bundle.js` file to be empty. See 18F/jekyll_pages_api_search#7.

cc: @afeld @lsgitter @wslack 