### PR TITLE
Expose the public projects api

### DIFF
--- a/deploy/etc/logrotate.d/nginx
+++ b/deploy/etc/logrotate.d/nginx
@@ -1,0 +1,15 @@
+/var/log/nginx/access.log {
+  rotate 12
+  monthly
+  compress
+  missingok
+  notifempty
+}
+
+/var/log/nginx/error.log {
+  rotate 12
+  monthly
+  compress
+  missingok
+  notifempty
+}

--- a/deploy/etc/logrotate.d/oauth2_proxy
+++ b/deploy/etc/logrotate.d/oauth2_proxy
@@ -1,0 +1,7 @@
+/var/log/oauth2_proxy/access.log {
+  rotate 12
+  monthly
+  compress
+  missingok
+  notifempty
+}

--- a/deploy/etc/nginx/vhosts/hub.conf
+++ b/deploy/etc/nginx/vhosts/hub.conf
@@ -27,6 +27,11 @@ server {
     alias /home/ubuntu/18f-hub/_site/assets/images/logo-18f-oauth.png;
   }
 
+  location /hub/api/projects {
+    root /home/ubuntu/hub/_site_public/;
+    index  api.json;
+  }
+
   location /deploy {
     proxy_pass http://localhost:4000/;
     proxy_http_version 1.1;


### PR DESCRIPTION
This is to facilitate https://18f.gsa.gov/dashboard/ deployment as discussed in 18F/dashboard#211. This is already running live, so I'll merge it myself.

Also took the liberty of adding `logrotate` configs.

cc: @gbinal @gboone