### PR TITLE
Update oauth2_proxy settings for MyUSA

### DIFF
--- a/deploy/usr/local/18f/etc/oauth2_proxy.cfg
+++ b/deploy/usr/local/18f/etc/oauth2_proxy.cfg
@@ -47,5 +47,14 @@ cookie_expire = "168h"
 cookie_refresh = "144h"
 cookie_https_only = true
 
+## To maintain backward compatibility so users won't have to refresh.
+cookie_key = "_oauthproxy"
+
+## MyUSA settings until staging.my.usa.gov change committed
+login_url = "https://staging.18f.gov/oauth/authorize"
+redeem_url = "https://staging.18f.gov/oauth/token"
+profile_url = "https://staging.18f.gov/api/v1/profile"
+validate_url = "https://staging.18f.gov/api/v1/tokeninfo"
+
 provider = "myusa"
 pass_access_token = true

--- a/deploy/usr/local/18f/etc/oauth2_proxy.cfg
+++ b/deploy/usr/local/18f/etc/oauth2_proxy.cfg
@@ -51,10 +51,10 @@ cookie_https_only = true
 cookie_key = "_oauthproxy"
 
 ## MyUSA settings until staging.my.usa.gov change committed
-login_url = "https://staging.18f.gov/oauth/authorize"
-redeem_url = "https://staging.18f.gov/oauth/token"
-profile_url = "https://staging.18f.gov/api/v1/profile"
-validate_url = "https://staging.18f.gov/api/v1/tokeninfo"
+login_url = "https://staging.my.usa.gov/oauth/authorize"
+redeem_url = "https://staging.my.usa.gov/oauth/token"
+profile_url = "https://staging.my.usa.gov/api/v1/profile"
+validate_url = "https://staging.my.usa.gov/api/v1/tokeninfo"
 
 provider = "myusa"
 pass_access_token = true


### PR DESCRIPTION
Also, keeps the _oauthproxy cookie name, which now defaults to _oauth2_proxy
in the latest release.

@jackiekazil @yozlet @adelevie This is already running in production.