### PR TITLE
Fix nginx config; make 403 page style standalone

### DIFF
--- a/_layouts/http_error.html
+++ b/_layouts/http_error.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
+<title>18F &mdash; {{ page.title }}</title>
+<style>{% asset normalize.css %}{% asset fonts.css %}{% asset error.css %}</style>
+<link href="https://fonts.googleapis.com/css?family=Raleway:400,700%7COpen+Sans:300,400,700" rel="stylesheet" type="text/css">
+</head>
+<body itemscope itemtype="http://schema.org/WebPage">
+
+  <div role="main" itemscope itemprop="mainContentOfPage">
+    {{ content }}
+  </div>
+</body>
+</html>

--- a/assets/css/error.scss
+++ b/assets/css/error.scss
@@ -1,0 +1,35 @@
+$blue: #1188ff;
+$open-sans: 'Open Sans','Helvetica Neue',Helvetica,Arial,sans-serif;
+$sans-serif: $open-sans;
+$base-font-family: $sans-serif;
+
+.fours {
+	background-color: $blue;
+	color: white;
+	padding-top: 130px;
+	padding-bottom: 130px;
+	margin-bottom: 30px;
+  a {
+    color: white;
+  }
+}
+.fours-content {
+	text-align: center;
+	h1 {
+		font-family: $base-font-family;
+		font-weight: 500;
+		font-size: 9em;
+	}
+	h2 {
+		font-size: 1.4em;
+		padding-top: 10px;
+		line-height: 1.3em;
+	}
+	p {
+		margin: 0;
+		font-size: 0.9em;
+	}
+	p+p {
+		margin-bottom: 100px;
+	}
+}

--- a/deploy/etc/nginx/vhosts/auth.conf
+++ b/deploy/etc/nginx/vhosts/auth.conf
@@ -21,7 +21,7 @@ server {
   location = /403/index.html {
     ssi on;
     root /home/ubuntu/hub/_site;
-    set $auth_continue_url $scheme://$server_name/$arg_rd;
+    set $auth_continue_url $scheme://$server_name$arg_rd;
   }
 
   location "~^/(?<target_host>[^/]+)(?<remaining_uri>.*)$" {

--- a/deploy/etc/nginx/vhosts/auth.conf
+++ b/deploy/etc/nginx/vhosts/auth.conf
@@ -10,13 +10,21 @@ server {
   include ssl/star.18f.gov.conf;
 
   location = /oauth2/callback {
+    proxy_intercept_errors on;
+    error_page 403 /403/index.html?rd=$arg_state;
     proxy_pass http://127.0.0.1:4180;
     proxy_connect_timeout 1;
     proxy_send_timeout 30;
     proxy_read_timeout 30;
   }
 
-  location ~/(?<target_host>[^/]+)(?<remaining_uri>.*)$ {
+  location = /403/index.html {
+    ssi on;
+    root /home/ubuntu/hub/_site;
+    set $auth_continue_url $scheme://$server_name/$arg_rd;
+  }
+
+  location "~^/(?<target_host>[^/]+)(?<remaining_uri>.*)$" {
     rewrite ^ $scheme://$target_host$remaining_uri;
   }
 

--- a/deploy/etc/nginx/vhosts/hub.conf
+++ b/deploy/etc/nginx/vhosts/hub.conf
@@ -71,7 +71,6 @@ server {
   listen 127.0.0.1:8080;
   server_name hub.18f.gov;
   port_in_redirect off;
-  error_page 403 /403/index.html;
   error_page 404 /404/index.html;
 
   location / {

--- a/pages/403.html
+++ b/pages/403.html
@@ -1,23 +1,24 @@
 ---
-layout: default
-permalink: /403/
-title: Unauthorized
+layout: http_error
+permalink: 403/
+title: Permission Denied
 ---
 <section class="fours">
   <div class="container">
     <div class="fours-content">
       <h1>403</h1>
       <h2><em>&quot;Who's there?&quot;</em><br/>
-        William Shakespeare, <em>The Tragedy of Hamlet, Prince of Demark</em></h2>
+        &mdash;William Shakespeare, <a href="http://shakespeare.mit.edu/hamlet/full.html"><em>The
+        Tragedy of Hamlet, Prince of Demark</em></a></h2>
     </div>
   </div>
 </section>
 
 <section class="container">
   <div class="fours-content">
-    <p>It seems you're not in our access list, or you may have accidentally
-    used the wrong account to authenticate with MyUSA. If so you can
-    <a href="https://staging.my.usa.gov/">return to MyUSA to log out</a>, then
-    log back in using the correct account.</p>
+    <p>It seems you're not in our access list. If you have accidentally used
+    the wrong account to authenticate with MyUSA, you can
+    <a href='https://staging.my.usa.gov/users/sign_out?continue=<!--# echo var="auth_continue_url" -->'>log
+    back into MyUSA using the correct account</a>.</p>
   </div>
 </section>

--- a/pages/403.html
+++ b/pages/403.html
@@ -16,7 +16,7 @@ title: Permission Denied
 
 <section class="container">
   <div class="fours-content">
-    <p>It seems you're not in our access list. If you have accidentally used
+    <p>It seems you're not on our access list. If you have accidentally used
     the wrong account to authenticate with MyUSA, you can
     <a href='https://staging.my.usa.gov/users/sign_out?continue=<!--# echo var="auth_continue_url" -->'>log
     back into MyUSA using the correct account</a>.</p>


### PR DESCRIPTION
The previous changes in #323 didn't actually do the trick, as the 403 is
coming from the oauth2_proxy, not directly from nginx. This change allows the
auth.18f.gov virtual server to intercept the 403 from oauth2_proxy during
the sign-in process, after the user has successfully logged into MyUSA but
using an account that isn't authorized to access the Hub.

The `auth.conf` config uses a Server-Side Include to serve a 403 page with a
custom link. This custom link allows the user to automatically log out of
MyUSA, and will also redirect to the intended URL once the user has logged
back in using the correct account. By changing the Hub's application URL in
MyUSA to https://auth.18f.gov/, this configuration works for all 18F
properties authenticated using the Hub's oauth2_proxy (including
https://tock.18f.gov/ and https://pages-staging.18f.gov/).

Since an unauthenticated user will not be able to load scrips and stylesheets,
there is a new http_error layout that cuts most of these things and inlines
the minimum styles necessary to maintain a consistent look (error.scss).

Also adds a helpful link to check the veracity of the Shaxper quote.

@afeld @wslack This is already running in production, and I've checked it several times. Ready to be merged whenever you're able.

cc: @leahbannon, since you hit this same problem a day before Will did.