### PR TITLE
Link directly to MyUSA account swap page from 403

### DIFF
--- a/deploy/etc/nginx/vhosts/auth.conf
+++ b/deploy/etc/nginx/vhosts/auth.conf
@@ -21,7 +21,14 @@ server {
   location = /403/index.html {
     ssi on;
     root /home/ubuntu/hub/_site;
-    set $auth_continue_url $scheme://$server_name$arg_rd;
+    set $auth_continue_url $scheme://$server_name/oauth2/start?rd=$arg_rd;
+  }
+
+  location = /oauth2/start {
+    proxy_pass http://127.0.0.1:4180;
+    proxy_connect_timeout 1;
+    proxy_send_timeout 30;
+    proxy_read_timeout 30;
   }
 
   location "~^/(?<target_host>[^/]+)(?<remaining_uri>.*)$" {

--- a/pages/403.html
+++ b/pages/403.html
@@ -9,7 +9,7 @@ title: Permission Denied
       <h1>403</h1>
       <h2><em>&quot;Who's there?&quot;</em><br/>
         &mdash;William Shakespeare, <a href="http://shakespeare.mit.edu/hamlet/full.html"><em>The
-        Tragedy of Hamlet, Prince of Demark</em></a></h2>
+        Tragedy of Hamlet, Prince of Denmark</em></a></h2>
     </div>
   </div>
 </section>

--- a/pages/403.html
+++ b/pages/403.html
@@ -17,8 +17,8 @@ title: Permission Denied
 <section class="container">
   <div class="fours-content">
     <p>It seems you're not on our access list. If you have accidentally used
-    the wrong account to authenticate with MyUSA, you can
+    the wrong account to authenticate, you can
     <a href='https://staging.my.usa.gov/users/sign_out?continue=<!--# echo var="auth_continue_url" -->'>log
-    back into MyUSA using the correct account</a>.</p>
+    back in using the correct account</a>.</p>
   </div>
 </section>


### PR DESCRIPTION
In #324, the link at the bottom of the page will take the user to the oauth2_proxy's sign-in page, which will then take the user to MyUSA to swap accounts before redirecting back to the intended page. This nginx config tweak enables the link to be built such that it leads directly to MyUSA while preserving the redirect to the intended page.

Also tweaked the 403 page's language to remove direct references to MyUSA. That much less information for the user to worry about when faced with a 403 from the Prince of Denmark.

cc: @wslack @afeld @leahbannon 

Also cc: @adelevie @yozlet @harrisj just because you might get a kick out of these neat Nginx tricks in this PR and #324 
. :-)