### PR TITLE
Complete _pages/private submodule migration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
 	path = _data/private
 	url = git@github.com:18F/data-private.git
 	branch = master
-[submodule "pages/private"]
+[submodule "_pages/private"]
 	path = _pages/private
 	url = git@github.com:18F/hub-pages-private.git
 	branch = master

--- a/_config.yml
+++ b/_config.yml
@@ -89,11 +89,12 @@ defaults:
         repo: 18F/hub
         branch: master
   - scope:
-      path: "/private"
+      path: "private"
+      type: pages
     values:
       edit_info:
         repo: 18F/hub-pages-private
-        prefix: pages/private/
+        prefix: _pages/private/
 
 editor_url: https://github.com/
 midas_url: "https://openopps.digitalgov.gov"


### PR DESCRIPTION
Should've been part of #327. Updates to https://hub.18f.gov/private aren't appearing because the repo on that server is pointing at an outdated submodule hash.

cc: @afeld @CaliforniaKara