### PR TITLE
Remove unnecessary permalinks after #327

### DIFF
--- a/_pages/101/git-submodules.md
+++ b/_pages/101/git-submodules.md
@@ -1,6 +1,5 @@
 ---
 title: Hub 101 - Working with Git Submodules
-permalink: /101/git-submodules/
 ---
 # {{ page.title }}
 

--- a/_pages/101/go.md
+++ b/_pages/101/go.md
@@ -1,6 +1,5 @@
 ---
 title: Hub 101 - Using the `./go` Script
-permalink: /101/go/
 ---
 # {{ page.title }}
 

--- a/_pages/101/internal-vs-public.md
+++ b/_pages/101/internal-vs-public.md
@@ -1,6 +1,5 @@
 ---
 title: Hub 101 - Internal vs. Public Hubs
-permalink: /101/internal-vs-public/
 ---
 # {{ page.title }}
 

--- a/_pages/101/rbenv.md
+++ b/_pages/101/rbenv.md
@@ -1,6 +1,5 @@
 ---
 title: Hub 101 - Setting up the Ruby environment with `rbenv`
-permalink: /101/rbenv/
 ---
 # {{ page.title }}
 

--- a/_pages/101/vagrant-and-ansible.md
+++ b/_pages/101/vagrant-and-ansible.md
@@ -1,6 +1,5 @@
 ---
 title: Hub 101 - Advanced Local Dev Environment Using Vagrant and Ansible
-permalink: /101/vagrant-and-ansible/
 ---
 # {{ page.title }}
 

--- a/_pages/18f-site/onboarding.md
+++ b/_pages/18f-site/onboarding.md
@@ -1,6 +1,5 @@
 ---
 title: Joining the 18F site team
-permalink: /18f-site/onboarding/
 ---
 # {{ page.title }}
 > This is a working draft for onboarding and offboarding team members to the

--- a/_pages/403.html
+++ b/_pages/403.html
@@ -1,6 +1,5 @@
 ---
 layout: http_error
-permalink: 403/
 title: Permission Denied
 ---
 <section class="fours">

--- a/_pages/404.html
+++ b/_pages/404.html
@@ -1,6 +1,5 @@
 ---
 layout: default
-permalink: /404/
 title: Page Not Found
 ---
 <section class="fours">

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,6 +1,5 @@
 ---
 title: About the 18F Hub
-permalink: /about/
 ---
 # {{ page.title }}
 

--- a/_pages/blogging.md
+++ b/_pages/blogging.md
@@ -1,6 +1,5 @@
 ---
 title: How to write a blog for 18F
-permalink: /blogging/
 ---
 # {{ page.title }}
 

--- a/_pages/clips.html
+++ b/_pages/clips.html
@@ -1,5 +1,4 @@
 ---
-permalink: /clips/
 title: News Clips
 ---
 <h1>{{ page.title }}</h1>

--- a/_pages/departments.html
+++ b/_pages/departments.html
@@ -1,5 +1,4 @@
 ---
-permalink: departments/
 title: Departments
 ---
 <h1>{{ page.title }}</h1>

--- a/_pages/docs.md
+++ b/_pages/docs.md
@@ -1,6 +1,5 @@
 ---
 title: 18F Team Documentation
-permalink: /docs/
 ---
 # {{ page.title }}
 

--- a/_pages/docsprint/guides/participation.md
+++ b/_pages/docsprint/guides/participation.md
@@ -1,5 +1,4 @@
 ---
-permalink: /docsprint/guides/participation/
 title: Doc Sprint Participation Guide
 ---
 # {{ page.title }}

--- a/_pages/docsprint/guides/planning.md
+++ b/_pages/docsprint/guides/planning.md
@@ -1,5 +1,4 @@
 ---
-permalink: /docsprint/guides/planning/
 title: Planning a Doc Sprint
 ---
 # {{ page.title }}

--- a/_pages/docsprint/onboarding.md
+++ b/_pages/docsprint/onboarding.md
@@ -1,5 +1,4 @@
 ---
-published: true
 title: Onboarding Doc Sprint
 ---
 # {{ page.title }}

--- a/_pages/docsprint/onboarding.md
+++ b/_pages/docsprint/onboarding.md
@@ -1,5 +1,4 @@
 ---
-permalink: /docsprint/onboarding/
 published: true
 title: Onboarding Doc Sprint
 ---

--- a/_pages/editing.md
+++ b/_pages/editing.md
@@ -1,6 +1,5 @@
 ---
 title: Editing Hub Content
-permalink: /editing/
 ---
 #{{ page.title }}
 

--- a/_pages/guidelines.md
+++ b/_pages/guidelines.md
@@ -1,6 +1,5 @@
 ---
 layout: bare
-permalink: /guidelines/
 title: Guidelines
 ---
 # {{ page.title }}

--- a/_pages/how-to.md
+++ b/_pages/how-to.md
@@ -1,6 +1,5 @@
 ---
 layout: "q-and-a"
-permalink: "how-to/"
 title: How to...
 ---
 # {{ page.title }}

--- a/_pages/interests.html
+++ b/_pages/interests.html
@@ -1,5 +1,4 @@
 ---
-permalink: /interests/
 category: interests
 layout: skills
 title: Interests

--- a/_pages/locations.html
+++ b/_pages/locations.html
@@ -1,5 +1,4 @@
 ---
-permalink: locations/
 scripts:
 - /assets/js/vendor/d3.v3.min.js
 - /assets/js/vendor/queue.v1.min.js

--- a/_pages/n00b.md
+++ b/_pages/n00b.md
@@ -1,6 +1,5 @@
 ---
 layout: "q-and-a"
-permalink: "/n00b/"
 title: "New to 18F?"
 ---
 # {{ page.title }}

--- a/_pages/projects.html
+++ b/_pages/projects.html
@@ -1,6 +1,5 @@
 ---
 layout: bare
-permalink: projects/
 title: Projects
 ---
 <h1>{{ page.title }}</h1>

--- a/_pages/skills.html
+++ b/_pages/skills.html
@@ -1,5 +1,4 @@
 ---
-permalink: /skills/
 category: skills
 layout: skills
 title: Skills

--- a/_pages/snippets.html
+++ b/_pages/snippets.html
@@ -1,5 +1,4 @@
 ---
-permalink: snippets/
 title: Snippets
 ---
 <h1>{{ page.title }}</h1>

--- a/_pages/snippets/guidelines.md
+++ b/_pages/snippets/guidelines.md
@@ -1,5 +1,4 @@
 ---
-permalink: /snippets/guidelines/
 title: Guidelines for Writing Snippets
 ---
 # {{ page.title }}

--- a/_pages/team.html
+++ b/_pages/team.html
@@ -1,6 +1,5 @@
 ---
 layout: bare
-permalink: /team/
 title: Team
 ---
 <h1>{{ page.title }}</h1>


### PR DESCRIPTION
Converting the `pages` directory to the `_pages` collection and setting the
default permalink in `_config.yml` makes most explicit `permalink:` attributes
unnecessary.

cc: @afeld @meiqimichelle