### PR TITLE
Fix /skills and /interests pages

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -41,10 +41,8 @@
 <!-- Browser warning, console message -->
 <script src="{% asset_path 18f.js %}"></script>
 
-{% for script_url in page.scripts %}
-{% unless script_url contains '.min.js' %}
-<script src="{{ script_url | split:"/" | last | asset_path }}"></script>
-{% else %}<script src="{{ site.baseurl }}{{ script_url }}"></script>{% endunless %}
-{% endfor %}
+{% for script_url in page.scripts %}{% unless script_url contains '.min.js' %}
+<script src="{{ script_url | split:"/" | last | asset_path }}"></script>{% else %}
+<script src="{{ site.baseurl }}{{ script_url }}"></script>{% endunless %}{% endfor %}
 
 {% jekyll_pages_api_search_load %}

--- a/_layouts/skills.html
+++ b/_layouts/skills.html
@@ -1,8 +1,5 @@
 ---
 layout: bare
-scripts:
-  - /assets/js/vendor/underscore.min.js
-  - /assets/js/team.js
 ---
 <h1>{{ page.category }}</h1>
 

--- a/_pages/interests.html
+++ b/_pages/interests.html
@@ -2,4 +2,7 @@
 category: interests
 layout: skills
 title: Interests
+scripts:
+- /assets/js/vendor/underscore.min.js
+- /assets/js/team.js
 ---

--- a/_pages/skills.html
+++ b/_pages/skills.html
@@ -2,4 +2,7 @@
 category: skills
 layout: skills
 title: Skills
+scripts:
+- /assets/js/vendor/underscore.min.js
+- /assets/js/team.js
 ---


### PR DESCRIPTION
At some point, and I'm not sure if it was a Jekyll upgrade or the move to turn
_pages into a collection, the scripts specified in _layouts/skills.html were
no longer inherited by _pages/skills.html and _pages/interests.html, causing
both pages and pages generated dynamically from them to be blank. Listing
the scripts directly in the page objects resolves the issue.

Took the liberty to reformat _includes/scripts.html as well.

cc: @afeld @dhcole @gboone @jeremiak 