### PR TITLE
Enable anyone at gsa.gov to view the 18F Hub

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,6 +38,7 @@ exclude:
 - Vagrantfile
 - bower.json
 - bower_components
+- coverage
 - deploy
 - go
 - pages/private/README.md

--- a/_layouts/auth_default.html
+++ b/_layouts/auth_default.html
@@ -1,0 +1,11 @@
+<div class="auth-include team-members">
+  <div class="team-member">
+    <div class="team-member-cell">
+      <a href="{{ site.baseurl }}/oauth2/sign_in"><span><!--# echo var="authenticated_user" --></span><br/>
+      Log Out</a>
+    </div>
+    <div class="team-member-cell">
+      <img src="{{ site.baseurl }}/{{ site.team_img_dir }}/{{ site.guest_user_img }}" alt="<!--# echo var="authenticated_user" -->"></a>
+    </div>
+  </div>
+</div>

--- a/_layouts/guest_user_auth_include.html
+++ b/_layouts/guest_user_auth_include.html
@@ -1,4 +1,11 @@
-<div class="auth-include">
-<span>{{ page.user.full_name }}</span>
-<img src="{{ site.baseurl }}/{{ site.team_img_dir }}/{{ site.guest_user_img }}" alt="{{ page.user.full_name }}">
+<div class="auth-include team-members">
+  <div class="team-member">
+    <div class="team-member-cell">
+      <a href="{{ site.baseurl }}/oauth2/sign_in"><span>{{ page.user.full_name }}</span><br/>
+      Log Out</a>
+    </div>
+    <div class="team-member-cell">
+      <img src="{{ site.baseurl }}/{{ site.team_img_dir }}/{{ site.guest_user_img }}" alt="<!--# echo var="{{ page.user.full_name }}" -->"></a>
+    </div>
+  </div>
 </div>

--- a/_layouts/team_member_auth_include.html
+++ b/_layouts/team_member_auth_include.html
@@ -1,11 +1,11 @@
 <div class="auth-include team-members">
   <div class="team-member">
     <div class="team-member-cell">
-      <a href="{{ site.baseurl }}/team/{{ page.user.name }}"><span>{{ page.user.full_name }}</span><br/>
+      <a href="{{ site.baseurl }}/team/{{ page.user.name }}"><span>{{ page.user.full_name }}</span></a><br/>
       <a href="{{ site.baseurl }}/oauth2/sign_in">Log Out</a>
     </div>
     <div class="team-member-cell">
-      <img src="{{ site.baseurl }}/{{ page.user.image }}" alt="{{ page.user.full_name }}"></a>
+      <a href="{{ site.baseurl }}/team/{{ page.user.name }}"><img src="{{ site.baseurl }}/{{ page.user.image }}" alt="{{ page.user.full_name }}"></a>
     </div>
   </div>
 </div>

--- a/auth/default.html
+++ b/auth/default.html
@@ -1,0 +1,3 @@
+---
+layout: auth_default
+---

--- a/auth/default.html
+++ b/auth/default.html
@@ -1,3 +1,4 @@
 ---
+title: Default authenticated user include
 layout: auth_default
 ---

--- a/deploy/etc/nginx/vhosts/hub.conf
+++ b/deploy/etc/nginx/vhosts/hub.conf
@@ -82,6 +82,14 @@ server {
       set $access_token $http_x_forwarded_access_token;
   }
 
+  location "~^/auth/(?<authenticated_user>[^/]+)/index.html$" {
+      ssi on;
+      root   /home/ubuntu/hub/_site;
+      default_type text/html;
+      try_files $uri /auth/default/index.html;
+      set $authenticated_user $http_x_forwarded_email;
+  }
+
   location /hub {
       root   /home/ubuntu/hub/_site_public;
       index  index.html api.json;

--- a/deploy/usr/local/18f/etc/oauth2_proxy.cfg
+++ b/deploy/usr/local/18f/etc/oauth2_proxy.cfg
@@ -16,9 +16,9 @@ upstreams = [
 pass_basic_auth = true
 
 ## Google Apps Domains to allow authentication for
-#google_apps_domains = [
-#    "gsa.gov"
-#]
+email_domains = [
+    "gsa.gov"
+]
 
 
 ## The OAuth2 Client ID, Secret


### PR DESCRIPTION
Adds a default auth include, used by nginx's `try_files` directive when a pregenerated auth include file for the authenticated user doesn't exist. Updates the existing auth include layouts slightly.

Already successfully tried it out on https://hub.18f.gov/ by manually updating the site and removing my own specific entries in `/auth/`.

cc: @gbinal @afeld @gboone 