### PR TITLE
Redirect: /content-style-guide -> /content-guide

### DIFF
--- a/deploy/etc/nginx/vhosts/pages.conf
+++ b/deploy/etc/nginx/vhosts/pages.conf
@@ -16,6 +16,10 @@ server {
   server_name  pages.18f.gov;
   include ssl/star.18f.gov.conf;
 
+  location "~^/content-style-guide/(?<remaining_uri>.*)$" {
+    return 301 https://$host/content-guide/$remaining_uri;
+  }
+
   location / {
     root   /home/ubuntu/pages-generated;
     index  index.html;


### PR DESCRIPTION
This is already running in prod. Try: https://pages.18f.gov/content-style-guide/. Might have to reload to get it to redirect if it’s cached. Works for all the different sections of the guide.

cc: @awfrancisco @emileighoutlaw @kategarklavs @gboone 