### PR TITLE
Create configuration for https://team-api.18f.gov/

### DIFF
--- a/deploy/etc/nginx/nginx.conf
+++ b/deploy/etc/nginx/nginx.conf
@@ -78,6 +78,7 @@ http {
   include /etc/nginx/vhosts/auth.conf;
   include /etc/nginx/vhosts/hub.conf;
   include /etc/nginx/vhosts/pages.conf;
+  include /etc/nginx/vhosts/team-api.conf;
   include /etc/nginx/vhosts/tock.conf;
 }
 

--- a/deploy/etc/nginx/vhosts/team-api.conf
+++ b/deploy/etc/nginx/vhosts/team-api.conf
@@ -1,0 +1,54 @@
+##
+# Team API vhost
+# /etc/nginx/vhosts/api.conf
+##
+
+# HTTP server
+
+server {
+  listen 80;
+  server_name  team-api.18f.gov;
+  return 301 https://$host$request_uri;
+}
+
+# HTTPS server (with SPDY enabled)
+server {
+  listen 443 ssl spdy;
+  server_name  team-api.18f.gov;
+  include ssl/star.18f.gov.conf;
+  include vhosts/auth-locations.conf;
+
+  location /deploy {
+    proxy_pass http://localhost:6000/;
+    proxy_http_version 1.1;
+    proxy_redirect off;
+
+    proxy_set_header Host   $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_max_temp_file_size 0;
+
+    proxy_connect_timeout 10;
+    proxy_send_timeout    30;
+    proxy_read_timeout    30;
+  }
+}
+
+server {
+  listen 127.0.0.1:8080;
+  server_name  team-api.18f.gov;
+  port_in_redirect off;
+
+  location / {
+    root   /home/ubuntu/team-api/_site/api;
+    index  index.html api.json;
+    default_type text/html;
+  }
+
+  location /public {
+    root   /home/ubuntu/team-api/_site_public;
+    index  index.html api.json;
+    default_type text/html;
+  }
+}


### PR DESCRIPTION
I need to get the hookshot server and whatnot set up in 18F/team-api and set up the deployment webhook on that repo, but at least the host is running.

cc: @arowla @jmcarp @monfresh 