### PR TITLE
Proxy to HTTPS

### DIFF
--- a/deploy/etc/nginx/vhosts/tock.conf
+++ b/deploy/etc/nginx/vhosts/tock.conf
@@ -24,7 +24,7 @@ server {
   port_in_redirect off;
 
   location / {
-    proxy_pass http://tock.cf.18f.us;
+    proxy_pass https://tock-app.18f.gov;
   }
 }
 
@@ -48,6 +48,6 @@ server {
   port_in_redirect off;
 
   location / {
-    proxy_pass http://tock-staging.cf.18f.us;
+    proxy_pass https://tock-app-staging.18f.gov;
   }
 }


### PR DESCRIPTION
Since we're now requiring SSL on all Cloud Foundry apps, the `proxy_pass` to http://tock.cf.18f.us is failing. This patch proxies instead to https://tock-app.18f.gov. Note: I added the "app" to distinguish between the nginx URL (tock.18f.gov) and the backend URL (tock-app.18f.gov).

ping @mbland @ramirezg @dlapiduz 