### PR TITLE
Update internal team-api root

### DIFF
--- a/deploy/etc/nginx/vhosts/team-api.conf
+++ b/deploy/etc/nginx/vhosts/team-api.conf
@@ -49,7 +49,7 @@ server {
   port_in_redirect off;
 
   location / {
-    root   /home/ubuntu/team-api/_site/api;
+    root   /home/ubuntu/team-api/_site;
     index  index.html api.json;
     default_type text/html;
     charset utf-8;


### PR DESCRIPTION
Now the internal API is rooted at https://team-api.18f.gov/api/, and the public API is rooted at https://team-api.18f.gov/public/api/, which is more consistent and makes the processing of `self:` links for individual items more straightforward.

Already running in production.

cc: @arowla @monfresh 