### PR TITLE
Pass through bodyParser.json() middleware options

### DIFF
--- a/deploy/hookshot.js
+++ b/deploy/hookshot.js
@@ -30,6 +30,10 @@ if (!branch || !command || !port) {
   process.exit(1);
 }
 
-hookshot('refs/heads/' + branch, command).listen(port);
+// Passed through to bodyParser.json().
+// https://www.npmjs.com/package/body-parser#limit
+var json_options = { limit: 1 << 20 };
+
+hookshot('refs/heads/' + branch, command, json_options).listen(port);
 
 console.log("18F Hub: Listening on port " + port + " for push events on " + branch + ".")


### PR DESCRIPTION
The public Hub push in 18F/hub#370 failed due to the webhook exceeding the
default 100K limit, just as in 18F/pages#15. This applies the same fix as
18F/pages. Still waiting on coreh/hookshot#12 to get merged upstream, so
I've already installed 18F/hookshot#json-options on the server:

```
npm install git+ssh://git@github.com/18F/hookshot.git#json-options
```

Note: I applied this in 18F/18f.gsa.gov#1102, but really should've just
applied it here. No harm done, however.

cc: @gboone 