### PR TITLE
Deploy public Hub with Hookshot request size fix

### DIFF
--- a/deploy/hookshot.js
+++ b/deploy/hookshot.js
@@ -30,6 +30,10 @@ if (!branch || !command || !port) {
   process.exit(1);
 }
 
-hookshot('refs/heads/' + branch, command).listen(port);
+// Passed through to bodyParser.json().
+// https://www.npmjs.com/package/body-parser#limit
+var json_options = { limit: 1 << 20 };
+
+hookshot('refs/heads/' + branch, command, json_options).listen(port);
 
 console.log("18F Hub: Listening on port " + port + " for push events on " + branch + ".")


### PR DESCRIPTION
Fixes problem with hookshot choking on webhooks that are too large, per #371.

cc: @gboone 