### PR TITLE
Style edits

### DIFF
--- a/_pages/guidelines.md
+++ b/_pages/guidelines.md
@@ -6,18 +6,18 @@ title: Guidelines
 
 * [Open Source Policy](https://github.com/18F/open-source-policy)
 * [API Standards](https://github.com/18F/api-standards)
-* [Frontend Styleguide](https://github.com/18F/frontend-style-guide){% unless site.public %}
-* [Leave, Telework, and Virtual Worker Policy]({{ site.baseurl }}/private/team-ops/leave-telework-virtual-worker-policy/)
+* [Front End Style Guide](https://github.com/18F/frontend-style-guide){% unless site.public %}
+* [Leave, telework, and virtual worker policy]({{ site.baseurl }}/private/team-ops/leave-telework-virtual-worker-policy/)
 * [Distributed Work Guide](https://docs.google.com/a/gsa.gov/document/d/16ozBoXxTnWutvp63mr5Q8phN21IRFD3LYm3BtgYkQg0/edit)
 * [Slack Guidelines]({{ site.baseurl }}/private/standards/slack/)
-* [Github Standards]({{ site.baseurl }}/private/standards/github/)
+* [GitHub Standards]({{ site.baseurl }}/private/standards/github/)
 * [Security Guidelines]({{ site.baseurl }}/private/standards/security/)
 * [Use of AWS]({{ site.baseurl }}/private/standards/aws/)
 * [Terms and Conditions]({{ site.baseurl }}/private/standards/terms-and-conditions/)
-* [How We Manage Client Accounts](https://docs.google.com/a/gsa.gov/document/d/1PIgWhoAifBmx6K-ihh8h9HRPQz1Mlj0TKHWv-UNWE-4/)
+* [How we manage client accounts](https://docs.google.com/a/gsa.gov/document/d/1PIgWhoAifBmx6K-ihh8h9HRPQz1Mlj0TKHWv-UNWE-4/)
 * [Using Ubuntu]({{ site.baseurl }}/private/team-ops/ubuntu/)
 * [How to hold events]({{ site.baseurl }}/private/team-ops/resources/event-info/)
-* [Publishing and Content Submission on 18f.gsa.gov]({{ site.baseurl }}/private/18F-site/publishing/){% endunless %}
+* [Publishing and content submission on 18f.gsa.gov]({{ site.baseurl }}/private/18F-site/publishing/){% endunless %}
 * [Content Guide](https://pages.18f.gov/content-guide/)
 
 We've tried to collect all of 18F's available standards and guidelines here. **If we've missed something or you see a way to improve this information**, please [file an issue](https://github.com/18F/hub/issues), click the 'edit this page' link at the bottom, or branch-add-pull-request from [the Hub repo](https://github.com/18F/hub).


### PR DESCRIPTION
Our content guide calls for "front end" not "frontend." Additionally, the things that are proper titles should be in title case, and everything else should be sentence case.