### PR TITLE
Remove invalid UTF-8 character from blog mission

### DIFF
--- a/_pages/blog-mission.md
+++ b/_pages/blog-mission.md
@@ -1,7 +1,7 @@
 ---
 title: Blog Mission Brief
 ---
-## Mission 
+## Mission
 
 The 18F blog is a place where we share what we’ve learned, what we’ve made, and what we do in an accessible, public way. We work in the open and share information that makes our work understandable and usable. We write frankly about the challenges we encounter and detail the lessons we learn when making tough decisions. Our blog sheds light on the innovation, integrity, and creativity of our teams and other teams across the government. We hope to lead by example, showing that government agencies can be straightforward and friendly in their communication.  
 


### PR DESCRIPTION
This was causing a `jekyll build` failure when the jekyll_pages_api tried to
extract the body text:

/usr/local/var/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/liquid-3.0.3/lib/liquid/standardfilters.rb:99:in `gsub': invalid byte sequence in UTF-8 (ArgumentError)
from /usr/local/var/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/liquid-3.0.3/lib/liquid/standardfilters.rb:99:in `strip_html'
from .../jekyll_pages_api/lib/jekyll_pages_api/filters.rb:27:in `block in text_only'
from .../jekyll_pages_api/lib/jekyll_pages_api/filters.rb:26:in `each'
from .../jekyll_pages_api/lib/jekyll_pages_api/filters.rb:26:in `reduce'
from .../jekyll_pages_api/lib/jekyll_pages_api/filters.rb:26:in `text_only'
from .../jekyll_pages_api/lib/jekyll_pages_api/page.rb:49:in `body_text'

cc: @afeld @gboone