### PR TITLE
Remove `proxy_set_header` directives from tock

### DIFF
--- a/deploy/etc/nginx/vhosts/tock.conf
+++ b/deploy/etc/nginx/vhosts/tock.conf
@@ -26,7 +26,6 @@ server {
   location / {
     proxy_pass https://tock-app.18f.gov/;
     proxy_http_version 1.1;
-    proxy_set_header Host   $host;
   }
 }
 
@@ -52,6 +51,5 @@ server {
   location / {
     proxy_pass https://tock-app-staging.18f.gov/;
     proxy_http_version 1.1;
-    proxy_set_header Host   $host;
   }
 }


### PR DESCRIPTION
Closes 18F/tock#223. Still don't know what the root cause was that caused the
previously-working configs to stop working--I suspect that something changed
in Cloud Foundry to re-allocate the original upstream IP address and
invalidated the existing routes to tock.18f.gov and tock-staging.18f.gov--but
this definitely resolves the issue (for now).

Already running in production.

cc: @jmcarp @ramirezg 
