### PR TITLE
Bust proxy_pass DNS cache; restore proxy 'Host:'

### DIFF
--- a/deploy/etc/nginx/vhosts/tock.conf
+++ b/deploy/etc/nginx/vhosts/tock.conf
@@ -24,8 +24,11 @@ server {
   port_in_redirect off;
 
   location / {
-    proxy_pass https://tock-app.18f.gov/;
+    resolver 8.8.8.8;
+    set $backend_upstream "https://tock-app.18f.gov";
+    proxy_pass $backend_upstream;
     proxy_http_version 1.1;
+    proxy_set_header Host $host;
   }
 }
 
@@ -49,7 +52,10 @@ server {
   port_in_redirect off;
 
   location / {
-    proxy_pass https://tock-app-staging.18f.gov/;
+    resolver 8.8.8.8;
+    set $backend_upstream "https://tock-app-staging.18f.gov";
+    proxy_pass $backend_upstream;
     proxy_http_version 1.1;
+    proxy_set_header Host $host;
   }
 }


### PR DESCRIPTION
Two problems arose with https://tock.18f.gov/ last night.

Problem the first, the original IP address for https://tock-app.18f.gov/
expired. nginx actually caches DNS responses for `proxy_pass` hosts when
they're hardcoded. The workaround: force it to be a variable, per:

  https://www.jethrocarr.com/2013/11/02/nginx-reverse-proxies-and-dns-resolution/

Problem the second, somehow the Cloud Foundry route for tock.18f.gov
disappeared. Once the DNS issues was (initially) resolved by restarting nginx,
https://tock.18f.gov/ started returning:

  `404 Not Found: Requested route ('tock.18f.gov') does not exist.`

Removing the `proxy_set_header Host $host` directive, originally added in
18F/hub#359, caused https://tock.18f.gov/ to work again, sort of. After
@batemapf made administrative changes, he was bounced back out to
https://tock-app.18f.gov/ instead.

After discussion with @jmcarp, @dlapiduz, and @GUI, we figured out the
cache-busting solution to the stale IP issue, and that restoring the
tock.18f.gov mapping in Cloud Foundry enabled us to restore the
`proxy_set_header` directive.

Already running in production. Admins reporting that all is again right with the world. Merging.