### PR TITLE
Attempt to fix styling, especially h1-h4

### DIFF
--- a/assets/_sass/_hub.scss
+++ b/assets/_sass/_hub.scss
@@ -16,6 +16,7 @@
 //********************************************************
 ul {
   list-style: disc inside none;
+  padding-bottom: 0.5em;
 
   li {
     margin-bottom: 0.25em;
@@ -311,10 +312,12 @@ margin-bottom: 20px;
 
 .bare-content {
   width: 100%;
-  h1 {
-    margin-top: 0.5em;
-    margin-bottom: 0.5em;
-  }
+  h1 { margin-top: 0.5em; margin-bottom: 0.5em; }
+  h2 { margin-top: 0.5em; margin-bottom: 0.5em; }
+  h3 { margin-top: 0.5em; margin-bottom: 0.5em; }
+  h4 { margin-top: 0.5em; margin-bottom: 0.5em; }
+  h5 { margin-top: 0.5em; margin-bottom: 0.5em; }
+  h6 { margin-top: 0.5em; margin-bottom: 0.5em; }
   h1:first-letter {
     text-transform: uppercase;
   }


### PR DESCRIPTION
I've tried to take a pass at tweaking some of the styles for headlines and unordered lists to make pages like https://hub.18f.gov/consulting/interviewing/core-values/ more appealing.

Before:

![before](https://cloud.githubusercontent.com/assets/301547/9621722/4114aed0-50f8-11e5-83eb-952b0735328a.png)

After:

![after](https://cloud.githubusercontent.com/assets/301547/9621725/4a0eef8c-50f8-11e5-83d2-34c49ad937dd.png)

However, my CSS/design capabilities are _extremely_ limited, and would love it if a true expert like  @noahmanger,  @meiqimichelle, or @jenniferthibault might have a couple spare cycles to do this up properly.

Or, @adelevie, if you think this gets us in the ballpark of what you and yours had in mind, feel free to merge.