### PR TITLE
Remove line on signal-noise in USDS Slack section

### DIFF
--- a/_pages/standards/Slack.md
+++ b/_pages/standards/Slack.md
@@ -45,7 +45,7 @@ Friends from other government teams can be invited into a project's channel or a
 
 #### Teammates from the United States Digital Service (USDS)
 
-One of our biggest collaborators is the USDS. You may see channels that end with `-usds` — members of the USDS across government are in these channels. In order to keep the signal to noise ratio high, please keep discussion focused on the project or task at hand in each channel. 
+One of our biggest collaborators is the USDS. You may see channels that end with `-usds` — members of the USDS across government are in these channels. 
 
 #### The public
 


### PR DESCRIPTION
This is superfluous for this section of the Slack standards - if it's only about signal-noise ratio, that applies to basically all of our on-topic channels, no matter who's in them.