### PR TITLE
Adding weekly intake standups

### DIFF
--- a/_pages/qa/calendar-items.md
+++ b/_pages/qa/calendar-items.md
@@ -11,4 +11,6 @@ title: Google calendar items
 
 * Tuesday 1:00 ET: follow-up action items
 
+* Thursday 12:00 ET: Weekly Intake Standup
+
 * Teams may post their daily stand times in the 18F product meetings calendar


### PR DESCRIPTION
Lots of folks have been suggesting folks attend the weekly intake standup when they're new - great way to get to know the way we work and the projects that are coming in. Also worth mentioned - I'm not sure what this Tuesday 1:00 ET meeting is - nobody has said anything to be about it. Might be worth clarifying or deleting?