### PR TITLE
Add engineering team talk signup info to onboarding page

### DIFF
--- a/_pages/onboarding.md
+++ b/_pages/onboarding.md
@@ -82,6 +82,8 @@ Welcome to 18F! We are so glad you are here.
 
 * Explore [employee discounts](../private/fed-discount-phone/), including about 15% on cellphone plans.
 
+* If you are not on the Delivery Engineering team, but are interested in attending monthly technical talks, email [Theresa Summa](mailto:theresa.summa@gsa.gov) and ask to be invited. You can also [submit a talk](https://docs.google.com/document/d/1FQLUofvibixHXg0iiUIdF9Up8djUrUL4xqU64sxHg-U/edit). If you are on the Delivery Engineering team, you will be invited automatically.
+
 ### Email and listservs
 
 * [Add a password]({{ site.baseurl }}/listserv-password/) to your GSA email listserv preferences (or change your subscriptions).

--- a/_pages/onboarding.md
+++ b/_pages/onboarding.md
@@ -82,7 +82,7 @@ Welcome to 18F! We are so glad you are here.
 
 * Explore [employee discounts](../private/fed-discount-phone/), including about 15% on cellphone plans.
 
-* If you are not on the Delivery Engineering team, but are interested in attending monthly technical talks, email [Theresa Summa](mailto:theresa.summa@gsa.gov) and ask to be invited. You can also [submit a talk](https://docs.google.com/document/d/1FQLUofvibixHXg0iiUIdF9Up8djUrUL4xqU64sxHg-U/edit). If you are on the Delivery Engineering team, you will be invited automatically.
+* If you are not on the Delivery Engineering team, but are interested in attending monthly technical talks, ask to be invited in #dev on Slack. You can also [submit a talk](https://docs.google.com/document/d/1FQLUofvibixHXg0iiUIdF9Up8djUrUL4xqU64sxHg-U/edit). If you are on the Delivery Engineering team, you will be invited automatically.
 
 ### Email and listservs
 


### PR DESCRIPTION
People outside of the engineering team need a way to learn about the monthly team talks and to get involved, if they're interested. Please feel free to reword.