### PR TITLE
Fix link to Slack Standards

### DIFF
--- a/_pages/qa/slack.md
+++ b/_pages/qa/slack.md
@@ -7,7 +7,7 @@ title: Slack setup
 
 Getting on Slack: [https://18f.slack.com/](https://18f.slack.com/). You will probably want to download the Slack desktop client from the App Store.
 
-* Remember to first review [18F's Slack standards](https://hub.18f.gov/private/standards/slack/). These are the required steps you need to take first.
+* Remember to first review [18F's Slack standards]({{ site.baseurl }}/standards/slack). These are the required steps you need to take first.
 * You'll automatically be added to several channels. The most important is #news, as it contains announcements from the 18F management team. Browse through the available channels. You may want to take a look at:
     * #questions (a friendly place to ask questions)
     * #it-issues (IT related questions)


### PR DESCRIPTION
Not a private page (anymore?).