### PR TITLE
Fix link with explicit linking syntax

### DIFF
--- a/_pages/qa/change-ent.md
+++ b/_pages/qa/change-ent.md
@@ -8,7 +8,7 @@ title: ENT Passwords
 
 ## Change or reset your GSA ENT password from outside the GSA network
 
-* Go to https://secureauth.gsa.gov. It says you can only use Internet Explorer, but Safari and Firefox work just fine. Chrome works for many people.
+* Go to (https://secureauth.gsa.gov)[https://secureauth.gsa.gov]. It says you can only use Internet Explorer, but Safari and Firefox work just fine. Chrome works for many people.
 * Navigate to the bottom left, “GSA AD Password Reset.” If you don’t see a link worded like this, you’re not using the right browser.
 * The only restriction is 15+ characters (no special, no upper/lower case, etc. required).
 * You can't reuse any of your last 10 passwords.


### PR DESCRIPTION
The automatic linking is being greedy (and stupid) and including the period, causing the link to break.