### PR TITLE
302 redirect from guides.18f.gov to pages.18f.gov

### DIFF
--- a/deploy/etc/nginx/vhosts/pages.conf
+++ b/deploy/etc/nginx/vhosts/pages.conf
@@ -89,3 +89,25 @@ server {
     default_type text/html;
   }
 }
+
+# guides.18f.gov redirects
+server {
+  listen 80;
+  server_name  guides.18f.gov;
+  return 301 https://$host$request_uri;
+}
+
+server {
+  listen 443 ssl spdy;
+  server_name  guides.18f.gov;
+  include ssl/star.18f.gov.conf;
+  include new_relic/status.conf;
+
+  location = / {
+    return 302 https://pages.18f.gov/guides/;
+  }
+
+  location / {
+    return 302 https://pages.18f.gov$request_uri;
+  }
+}


### PR DESCRIPTION
Running in production. Will consider whether to make guides.18f.gov the permanent host at some point.

cc: @emileighoutlaw 