### PR TITLE
Set default args to empty list for `./go build`

### DIFF
--- a/go
+++ b/go
@@ -97,7 +97,7 @@ def_command :validate, 'Build, then validate no internal links are broken' do
 end
 
 def_command(
-  :build, 'Builds the internal and external versions of the Hub') do |args|
+  :build, 'Builds the internal and external versions of the Hub') do |args = []|
   puts 'Building internal version...'
   build_jekyll args
   puts 'Building public version...'


### PR DESCRIPTION
The https://hub.18f.gov/hub/ build was breaking because the `args` parameter was passed as `nil` instead of `[]`. Setting the default value for `args` explicitly rectifies this.

cc: @afeld @ccostino @ertzeid @catherinedevlin 