### PR TITLE
Update Add Contact Instructions

### DIFF
--- a/_pages/qa/add-contact.md
+++ b/_pages/qa/add-contact.md
@@ -9,7 +9,7 @@ title: Adding Your Contact Information
 
 * Add your contact info to the [team contact list](https://docs.google.com/a/gsa.gov/spreadsheet/ccc?key=0Auy3CqI2T1nndGd3U3h3ZkVXQVhvVkhBcDhZWTRIblE&usp=drive_web#gid=3).
 * [https://hub.18f.gov (The Hub)](https://hub.18f.gov) is our internal team, project, and documentation directory. If you're not reading this on the Hub and you can't access it, send [Mike Bland](mailto:michael.bland@gsa.gov)) your [gsa.gov](http://gsa.gov/) email address (when you have it). He'll add you to the access list.
-* Once you have access to the 18F GitHub team, add your info to [the `team` directory of the `data-private` repository](https://github.com/18F/data-private/tree/master/team). There will already be a `yml` file there with your basic info (this is what gave you access to Hub in the first place), but add your skills and interests. The `yml` file serves several purposes:
+* Once you have access to the 18F GitHub team, add your info to [the `team` directory of the `team-api.18f.gov` repository](https://github.com/18F/team-api.18f.gov/tree/master/_data/team). There will already be a `yml` file there with your basic info (this is what gave you access to Hub in the first place), but add your skills and interests. The `yml` file serves several purposes:
 
     * Populates profile on the Hub that allows cross-linking across projects, working groups, guilds, locations, skills, and interests, as well as [snippets](https://hub.18f.gov/snippets/).
     * Provides info for the [Team API](https://team-api.18f.gov/api/) that also does all this cross-linking


### PR DESCRIPTION
This changeset updates the Add Contact Instructions found in the Hub so that they no longer reference the `data-private` repository.  This is in reference to this issue: https://github.com/18F/team-api.18f.gov/issues/169

/cc @mtorres253 @andrewmaier @catherinedevlin @mbland