### PR TITLE
Copy changes to better communicate Hub status

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -68,7 +68,7 @@ url: https://hub.18f.gov
 
 # metadata
 title: 18F Hub
-description: "The go-to place for all team information "
+description: "The Hub is Getting a New Look"
 generated_page_title_format: '%s &mdash; 18F Hub'
 
 # private data


### PR DESCRIPTION
Updating message on Hub homepage to reflect current status, as well as implementing some of the redirects (in the top nav, homepage and footer) documented here: https://waffle.io/18F/hub/cards/56d5e5b00f58ca0300362c43