### PR TITLE
update vulnerable gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ end
 
 group :test do
   gem 'rake'
-  gem 'html-proofer'
+  gem 'html-proofer', '~> 2.6.4'
   gem 'minitest'
   gem 'codeclimate-test-reporter'
   gem 'test_temp_file_helper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    RedCloth (4.2.9)
+    RedCloth (4.3.0)
     about_yml (0.0.8)
       json-schema
       octokit (~> 3.0)
@@ -186,4 +186,4 @@ DEPENDENCIES
   weekly_snippets
 
 BUNDLED WITH
-   1.10.6
+   1.12.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,12 @@ GEM
       json-schema
       octokit (~> 3.0)
       safe_yaml (~> 1.0)
+    activesupport (4.2.6)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
     addressable (2.3.8)
     bourbon (4.2.6)
       sass (~> 3.4)
@@ -23,7 +29,7 @@ GEM
     docile (1.1.5)
     domain_name (0.5.25)
       unf (>= 0.0.5, < 1.0.0)
-    ethon (0.8.0)
+    ethon (0.9.0)
       ffi (>= 1.3.0)
     execjs (2.6.0)
     faraday (0.9.2)
@@ -37,7 +43,8 @@ GEM
     hash-joiner (0.0.7)
       safe_yaml
     hike (1.2.3)
-    html-proofer (2.5.1)
+    html-proofer (2.6.4)
+      activesupport (~> 4.2)
       addressable (~> 2.3)
       colored (~> 1.2)
       mercenary (~> 0.3.2)
@@ -48,6 +55,7 @@ GEM
     htmlentities (4.3.4)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
+    i18n (0.7.0)
     jekyll (3.0.0)
       colorator (~> 0.1)
       jekyll-sass-converter (~> 1.0)
@@ -88,19 +96,19 @@ GEM
     listen (3.0.3)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
-    mercenary (0.3.5)
+    mercenary (0.3.6)
     mime-types (2.6.2)
     mini_magick (4.3.6)
-    mini_portile (0.6.2)
+    mini_portile2 (2.0.0)
     minitest (5.8.2)
     multi_json (1.11.2)
     multipart-post (2.0.0)
     netrc (0.10.3)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
     octokit (3.8.0)
       sawyer (~> 0.6.0, >= 0.5.3)
-    parallel (1.6.1)
+    parallel (1.8.0)
     rack (1.6.4)
     rake (10.4.2)
     rb-fsevent (0.9.6)
@@ -145,10 +153,13 @@ GEM
       libv8 (~> 3.16.14.0)
       ref
     thor (0.19.1)
+    thread_safe (0.3.5)
     tilt (1.4.1)
     tins (1.6.0)
     typhoeus (0.8.0)
       ethon (>= 0.8.0)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
     uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
@@ -156,7 +167,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.1)
     weekly_snippets (0.0.2)
-    yell (2.0.5)
+    yell (2.0.6)
 
 PLATFORMS
   ruby
@@ -169,7 +180,7 @@ DEPENDENCIES
   coveralls
   go_script
   hash-joiner
-  html-proofer
+  html-proofer (~> 2.6.4)
   jekyll
   jekyll-assets
   jekyll-sitemap


### PR DESCRIPTION
Update gems in response to https://gemnasium.com/github.com/18F/hub/alerts. I understand it's not critical given that it's a static site but it's good practice to keep things up to date.
