### PR TITLE
Correct the spelling of "Roanoke"

### DIFF
--- a/_data/locations.yml
+++ b/_data/locations.yml
@@ -78,7 +78,7 @@
   longitude: -78.787996
   timezone: 'Eastern Time Zone (UTC-05:00)'
 - code: ROA
-  label: Roanoake, VA
+  label: Roanoke, VA
   latitude: 37.324767
   longitude: -79.9792301
   timezone: 'Eastern Time Zone (UTC-05:00)'


### PR DESCRIPTION
e.g., http://www.roanokeva.gov/
